### PR TITLE
Make closed workload reconfigurable

### DIFF
--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/usage/ClosedWorkload.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/usage/ClosedWorkload.java
@@ -40,7 +40,7 @@ public class ClosedWorkload implements ICancellableWorkloadDriver {
     public void run() {
         startUsers(population);
     }
-    
+
     @Override
     public void cancel() {
         this.setPopulation(0);
@@ -66,9 +66,6 @@ public class ClosedWorkload implements ICancellableWorkloadDriver {
         }
     }
 
-    /**
-     *
-     */
     private void startUsers(final int count) {
         for (int i = 0; i < count; i++) {
             final ClosedWorkloadUser user = (ClosedWorkloadUser) userFactory.createUser();

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/usage/ClosedWorkload.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/usage/ClosedWorkload.java
@@ -15,6 +15,8 @@ public class ClosedWorkload implements ICancellableWorkloadDriver {
     private final int population;
     private final IUserFactory userFactory;
     private final Queue<ClosedWorkloadUser> users;
+    /** is null, unless a new think time has been set. */
+    private String newThinkTime = null;
 
     /**
      * Constructor of the closed workload driver
@@ -69,8 +71,18 @@ public class ClosedWorkload implements ICancellableWorkloadDriver {
     private void startUsers(final int count) {
         for (int i = 0; i < count; i++) {
             final ClosedWorkloadUser user = (ClosedWorkloadUser) userFactory.createUser();
+            if (newThinkTime != null) {
+                user.setThinkTime(newThinkTime);
+            }
             user.startUserLife();
             this.users.add(user);
+        }
+    }
+
+    public void setThinkTime(final String newThinkTime) {
+        this.newThinkTime = newThinkTime;
+        for (ClosedWorkloadUser user : users) {
+            user.setThinkTime(newThinkTime);
         }
     }
 }

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/usage/ClosedWorkload.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/usage/ClosedWorkload.java
@@ -13,7 +13,7 @@ import java.util.Queue;
 public class ClosedWorkload implements ICancellableWorkloadDriver {
 
     private final int population;
-    private final IUserFactory userFactory;
+    private final IClosedWorkloadUserFactory userFactory;
     private final Queue<ClosedWorkloadUser> users;
     /** is null, unless a new think time has been set. */
     private String newThinkTime = null;
@@ -26,7 +26,7 @@ public class ClosedWorkload implements ICancellableWorkloadDriver {
      * @param population
      *            Number of users in the system
      */
-    public ClosedWorkload(final IUserFactory userFactory, final int population) {
+    public ClosedWorkload(final IClosedWorkloadUserFactory userFactory, final int population) {
         super();
         this.userFactory = userFactory;
         this.population = population;
@@ -71,16 +71,13 @@ public class ClosedWorkload implements ICancellableWorkloadDriver {
     private void startUsers(final int count) {
         for (int i = 0; i < count; i++) {
             final ClosedWorkloadUser user = (ClosedWorkloadUser) userFactory.createUser();
-            if (newThinkTime != null) {
-                user.setThinkTime(newThinkTime);
-            }
             user.startUserLife();
             this.users.add(user);
         }
     }
 
     public void setThinkTime(final String newThinkTime) {
-        this.newThinkTime = newThinkTime;
+        userFactory.setThinkTimeSpec(newThinkTime);
         for (ClosedWorkloadUser user : users) {
             user.setThinkTime(newThinkTime);
         }

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/usage/ClosedWorkloadUser.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/usage/ClosedWorkloadUser.java
@@ -23,7 +23,7 @@ public class ClosedWorkloadUser extends SimuComSimProcess implements IUser {
     private static final Logger LOGGER = Logger.getLogger(ClosedWorkloadUser.class.getName());
 
     private final IScenarioRunner scenarioRunner;
-    private final String thinkTime;
+    private String thinkTime;
 
     // private static int USERCOUNT = 0;
     private int runCount = 0;
@@ -154,4 +154,7 @@ public class ClosedWorkloadUser extends SimuComSimProcess implements IUser {
         this.requestStop = true;
     }
 
+    public void setThinkTime(final String newThinkTimeSpec) {
+        this.thinkTime = newThinkTimeSpec;
+    }
 }

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/usage/ClosedWorkloadUser.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/usage/ClosedWorkloadUser.java
@@ -72,8 +72,8 @@ public class ClosedWorkloadUser extends SimuComSimProcess implements IUser {
                 if (getModel().getConfiguration().getSimulateFailures()) {
                     this.getModel().getFailureStatistics().increaseRunCount();
                     if (getModel().getConfiguration().isDebug()) {
-                        this.getModel().getFailureStatistics()
-                                .printRunCount(LOGGER, getModel().getSimulationControl().getCurrentSimulationTime());
+                        this.getModel().getFailureStatistics().printRunCount(LOGGER,
+                                getModel().getSimulationControl().getCurrentSimulationTime());
                     }
                 }
                 scenarioRunner(this);
@@ -82,8 +82,8 @@ public class ClosedWorkloadUser extends SimuComSimProcess implements IUser {
                 }
             } catch (final FailureException exception) {
                 if (getModel().getConfiguration().getSimulateFailures()) {
-                    this.getModel().getFailureStatistics()
-                            .increaseUnhandledFailureCounter(exception.getFailureType(), currentSessionId);
+                    this.getModel().getFailureStatistics().increaseUnhandledFailureCounter(exception.getFailureType(),
+                            currentSessionId);
                 }
             } finally {
                 // Increase measurements counter manually as usage scenario run
@@ -113,7 +113,7 @@ public class ClosedWorkloadUser extends SimuComSimProcess implements IUser {
      */
     @Override
     public void scenarioRunner(final SimuComSimProcess thread) {
-    	// execute
+        // execute
         ((TriggeredProbe) this.usageStartStopProbes.get(0)).takeMeasurement(getRequestContext());
         this.scenarioRunner.scenarioRunner(thread);
         ((TriggeredProbe) this.usageStartStopProbes.get(1)).takeMeasurement(getRequestContext());

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/usage/ClosedWorkloadUserFactory.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/usage/ClosedWorkloadUserFactory.java
@@ -10,9 +10,9 @@ import de.uka.ipd.sdq.simucomframework.model.SimuComModel;
  * 
  * @author Steffen Becker, Sebastian Lehrig
  */
-public abstract class ClosedWorkloadUserFactory extends AbstractWorkloadUserFactory implements IUserFactory {
+public abstract class ClosedWorkloadUserFactory extends AbstractWorkloadUserFactory implements IClosedWorkloadUserFactory {
 
-    private final String thinkTime;
+    private String thinkTime;
 
     public ClosedWorkloadUserFactory(final SimuComModel model, final String thinkTimeSpec, final String usageScenarioURI) {
         this(model, thinkTimeSpec, (UsageScenario) EMFLoadHelper.loadAndResolveEObject(usageScenarioURI));
@@ -31,9 +31,14 @@ public abstract class ClosedWorkloadUserFactory extends AbstractWorkloadUserFact
      * @see de.uka.ipd.sdq.simucomframework.usage.IUserFactory#createUser()
      */
     @Override
-    public IUser createUser() {
+    public ClosedWorkloadUser createUser() {
         final IScenarioRunner scenarioRunner = this.createScenarioRunner();
         return new ClosedWorkloadUser(model, "ClosedUser", scenarioRunner, thinkTime, usageStartStopProbes);
+    }
+    
+    @Override
+    public void setThinkTimeSpec(String thinkTimeSpec) {
+        this.thinkTime = thinkTimeSpec;
     }
 
     /**

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/usage/IClosedWorkloadUserFactory.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/usage/IClosedWorkloadUserFactory.java
@@ -1,0 +1,17 @@
+package de.uka.ipd.sdq.simucomframework.usage;
+
+/**
+ * Interface for factories creating closed workload users.
+ * 
+ * @author Dominik Werle
+ * 
+ */
+public interface IClosedWorkloadUserFactory extends IUserFactory {
+    ClosedWorkloadUser createUser();
+    
+    /**
+     * Sets a new think time specification that is applied to newly created users.
+     * @param thinkTimeSpec the new tink time specification. Must not be null.
+     */
+    void setThinkTimeSpec(String thinkTimeSpec);
+}


### PR DESCRIPTION
This change is a bit tricky, because the de.uka.ipd.sdq.simucomframework.usage.ClosedWorkload does not know the think time, but keeps a reference to a IUserFactory that knows about the think time and uses it, when new users are requested.

To keep the change local, I decided to change the think time upon creation, which is a bit hacky but does not break the API (see de.uka.ipd.sdq.simucomframework.usage.ClosedWorkload.startUsers(int)).

If it would be better to change in all projects, I can also do that.

Note: I also cleaned up, so reviewing 265f4c7 is probably better (fb5cb34 is only clean up).