### PR TITLE
[SIMULIZAR-115] Added capabilities for dynamic assembly allocation lookup

### DIFF
--- a/bundles/de.uka.ipd.sdq.pcm.codegen.simucom/src-transforms/de/uka/ipd/sdq/pcm/codegen/simucom/transformations/sim/SimAllocationXpt.xtend
+++ b/bundles/de.uka.ipd.sdq.pcm.codegen.simucom/src-transforms/de/uka/ipd/sdq/pcm/codegen/simucom/transformations/sim/SimAllocationXpt.xtend
@@ -36,7 +36,7 @@ class SimAllocationXpt extends AllocationXpt {
 			package «a.fqnAllocationContextPackage()»;
 			 
 			public class «a.fqnAllocationContextClass()» 
-			extends de.uka.ipd.sdq.simucomframework.Context {
+			extends de.uka.ipd.sdq.simucomframework.SimuComContext {
 				public «a.fqnAllocationContextClass()»(de.uka.ipd.sdq.simucomframework.model.SimuComModel myModel) {
 					super(myModel);
 				}

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/Context.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/Context.java
@@ -37,7 +37,7 @@ public abstract class Context extends StackContext {
      * Simulation model
      */
     private SimuComModel myModel = null;
-    
+
     /**
      * Initialise a new context for the given simulation model
      * 
@@ -45,7 +45,7 @@ public abstract class Context extends StackContext {
      *            The simulation model used in this context
      */
     public Context(SimuComModel myModel) {
-    	if (myModel != null) { // This is for the prototype mapping, where we
+        if (myModel != null) { // This is for the prototype mapping, where we
             // don't need resources
             this.registry = myModel.getResourceRegistry();
             this.myModel = myModel;
@@ -95,8 +95,21 @@ public abstract class Context extends StackContext {
         return (SimulatedLinkingResourceContainer) container;
     }
 
+    /**
+     * The lookup allows to find the suitable simulation entity of the
+     * ResourceContainer to which an AssemblyContext is deployed to.
+     * 
+     * Subclasses need to provide the concrete implementation of the lookup mechanism.
+     * 
+     * @return the AssemblyContext allocation lookup
+     */
     public abstract IAssemblyAllocationLookup<AbstractSimulatedResourceContainer> getAssemblyAllocationLookup();
     
+    /**
+     * Provides access to simulation entities of resource containers based on their model entities.
+     * 
+     * @return the access facade to simulated resource containers.
+     */
 	public ISimulatedModelEntityAccess<ResourceContainer, AbstractSimulatedResourceContainer> getSimulatedResourceContainerAccess() {
 		return this.registry::getResourceContainer;
 	}

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/SimuComContext.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/SimuComContext.java
@@ -18,60 +18,61 @@ import de.uka.ipd.sdq.simucomframework.resources.IAssemblyAllocationLookup.HashM
  * 
  * Context of each thread in SimuCom simulation.
  * 
- * This class contains the functionality previously contained in <code>Context</code> which only
- * works for SimuCom simulations.
+ * This class contains the functionality previously contained in
+ * <code>Context</code> which only works for SimuCom simulations.
  * 
  * @author Sebastian Krach
  *
  */
 public abstract class SimuComContext extends Context {
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 8628196416449895566L;
-	
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 8628196416449895566L;
+
     /**
      * AssemblyContextID -> PassiveRessource
      */
     private final HashMap<String, IPassiveResource> assemblyPassiveResourceHash = new HashMap<String, IPassiveResource>();
 
     /**
-     * This Hashmap constitutes the backing storage for the static deployment lookup table
-     * of SimuCom simulations
+     * This Hashmap constitutes the backing storage for the static deployment lookup
+     * table of SimuCom simulations
      * 
      * AssemblyContextID -> Abstract SimulatedResourceContainer
      */
-	private Map<String, AbstractSimulatedResourceContainer> assemblyLinkMap = new HashMap<>();
-	
-	private IAssemblyAllocationLookup<AbstractSimulatedResourceContainer> assemblyLinkLookup = 
-			new HashMapAssemblyAllocationLookup<AbstractSimulatedResourceContainer>(assemblyLinkMap);
+    private Map<String, AbstractSimulatedResourceContainer> assemblyLinkMap = new HashMap<>();
 
-	public SimuComContext(SimuComModel myModel) {
-		super(myModel);
-		initialiseAssemblyContextLookup();
-	}
+    private IAssemblyAllocationLookup<AbstractSimulatedResourceContainer> assemblyLinkLookup = 
+            new HashMapAssemblyAllocationLookup<AbstractSimulatedResourceContainer>(assemblyLinkMap);
 
-	/**
-	 * Create a deployment relationship between the given assembly context and the
-	 * given resource container
-	 * 
-	 * @param assemblyContextID   ID of the assembly context to allocate
-	 * @param resourceContainerID ID of the resource container on which the assembly
-	 *                            context is allocated
-	 */
-	protected void linkAssemblyContextAndResourceContainer(String assemblyContextID, String resourceContainerID) {
-		assert getSimulatedResourceContainerAccess().getSimulatedEntity(resourceContainerID) != null;
-		AbstractSimulatedResourceContainer container = getSimulatedResourceContainerAccess()
-				.getSimulatedEntity(resourceContainerID);
-		assemblyLinkMap.put(assemblyContextID, container);
-	}
-	
-	/**
-	 * This method is used by SimuCom simulation code to look up simulated instances
-	 * of passive resources based on the assembly context
-	 */
+    public SimuComContext(SimuComModel myModel) {
+        super(myModel);
+        initialiseAssemblyContextLookup();
+    }
+
+    /**
+     * Create a deployment relationship between the given assembly context and the
+     * given resource container
+     * 
+     * @param assemblyContextID   ID of the assembly context to allocate
+     * @param resourceContainerID ID of the resource container on which the assembly
+     *                            context is allocated
+     */
+    protected void linkAssemblyContextAndResourceContainer(String assemblyContextID, String resourceContainerID) {
+        assert getSimulatedResourceContainerAccess().getSimulatedEntity(resourceContainerID) != null;
+        AbstractSimulatedResourceContainer container = getSimulatedResourceContainerAccess()
+                .getSimulatedEntity(resourceContainerID);
+        assemblyLinkMap.put(assemblyContextID, container);
+    }
+
+    /**
+     * This method is used by SimuCom simulation code to look up simulated instances
+     * of passive resources based on the assembly context
+     */
     public IPassiveResource getPassiveRessourceInContext(final String resourceURI,
-            final AssemblyContext assemblyContext, AbstractSimulatedResourceContainer resourceContainer, long capacity) {
+            final AssemblyContext assemblyContext, AbstractSimulatedResourceContainer resourceContainer,
+            long capacity) {
         final PassiveResource resource = (PassiveResource) EMFLoadHelper.loadAndResolveEObject(resourceURI);
         IPassiveResource pr = assemblyPassiveResourceHash.get(assemblyContext.getId() + resource.getId());
 
@@ -84,15 +85,15 @@ public abstract class SimuComContext extends Context {
         return pr;
     }
 
-	/**
-	 * Template method to be filled in by the generator. Calles
-	 * linkAssemblyContextAndResourceContainer to create the deployment specified in
-	 * the allocation model
-	 */
-	protected abstract void initialiseAssemblyContextLookup();
-	
-	@Override
-	public IAssemblyAllocationLookup<AbstractSimulatedResourceContainer> getAssemblyAllocationLookup() {
-		return assemblyLinkLookup;
-	}
+    /**
+     * Template method to be filled in by the generator. Calles
+     * linkAssemblyContextAndResourceContainer to create the deployment specified in
+     * the allocation model
+     */
+    protected abstract void initialiseAssemblyContextLookup();
+
+    @Override
+    public IAssemblyAllocationLookup<AbstractSimulatedResourceContainer> getAssemblyAllocationLookup() {
+        return assemblyLinkLookup;
+    }
 }

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/SimuComContext.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/SimuComContext.java
@@ -10,9 +10,9 @@ import org.palladiosimulator.pcm.repository.PassiveResource;
 import de.uka.ipd.sdq.scheduler.IPassiveResource;
 import de.uka.ipd.sdq.simucomframework.model.SimuComModel;
 import de.uka.ipd.sdq.simucomframework.resources.AbstractSimulatedResourceContainer;
+import de.uka.ipd.sdq.simucomframework.resources.HashMapAssemblyAllocationLookup;
 import de.uka.ipd.sdq.simucomframework.resources.IAssemblyAllocationLookup;
 import de.uka.ipd.sdq.simucomframework.resources.SimulatedResourceContainer;
-import de.uka.ipd.sdq.simucomframework.resources.IAssemblyAllocationLookup.HashMapAssemblyAllocationLookup;
 
 /**
  * 

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/SimuComContext.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/SimuComContext.java
@@ -1,0 +1,98 @@
+package de.uka.ipd.sdq.simucomframework;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.palladiosimulator.commons.emfutils.EMFLoadHelper;
+import org.palladiosimulator.pcm.core.composition.AssemblyContext;
+import org.palladiosimulator.pcm.repository.PassiveResource;
+
+import de.uka.ipd.sdq.scheduler.IPassiveResource;
+import de.uka.ipd.sdq.simucomframework.model.SimuComModel;
+import de.uka.ipd.sdq.simucomframework.resources.AbstractSimulatedResourceContainer;
+import de.uka.ipd.sdq.simucomframework.resources.IAssemblyAllocationLookup;
+import de.uka.ipd.sdq.simucomframework.resources.SimulatedResourceContainer;
+import de.uka.ipd.sdq.simucomframework.resources.IAssemblyAllocationLookup.HashMapAssemblyAllocationLookup;
+
+/**
+ * 
+ * Context of each thread in SimuCom simulation.
+ * 
+ * This class contains the functionality previously contained in <code>Context</code> which only
+ * works for SimuCom simulations.
+ * 
+ * @author Sebastian Krach
+ *
+ */
+public abstract class SimuComContext extends Context {
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 8628196416449895566L;
+	
+    /**
+     * AssemblyContextID -> PassiveRessource
+     */
+    private final HashMap<String, IPassiveResource> assemblyPassiveResourceHash = new HashMap<String, IPassiveResource>();
+
+    /**
+     * This Hashmap constitutes the backing storage for the static deployment lookup table
+     * of SimuCom simulations
+     * 
+     * AssemblyContextID -> Abstract SimulatedResourceContainer
+     */
+	private Map<String, AbstractSimulatedResourceContainer> assemblyLinkMap = new HashMap<>();
+	
+	private IAssemblyAllocationLookup<AbstractSimulatedResourceContainer> assemblyLinkLookup = 
+			new HashMapAssemblyAllocationLookup<AbstractSimulatedResourceContainer>(assemblyLinkMap);
+
+	public SimuComContext(SimuComModel myModel) {
+		super(myModel);
+		initialiseAssemblyContextLookup();
+	}
+
+	/**
+	 * Create a deployment relationship between the given assembly context and the
+	 * given resource container
+	 * 
+	 * @param assemblyContextID   ID of the assembly context to allocate
+	 * @param resourceContainerID ID of the resource container on which the assembly
+	 *                            context is allocated
+	 */
+	protected void linkAssemblyContextAndResourceContainer(String assemblyContextID, String resourceContainerID) {
+		assert getSimulatedResourceContainerAccess().getSimulatedEntity(resourceContainerID) != null;
+		AbstractSimulatedResourceContainer container = getSimulatedResourceContainerAccess()
+				.getSimulatedEntity(resourceContainerID);
+		assemblyLinkMap.put(assemblyContextID, container);
+	}
+	
+	/**
+	 * This method is used by SimuCom simulation code to look up simulated instances
+	 * of passive resources based on the assembly context
+	 */
+    public IPassiveResource getPassiveRessourceInContext(final String resourceURI,
+            final AssemblyContext assemblyContext, AbstractSimulatedResourceContainer resourceContainer, long capacity) {
+        final PassiveResource resource = (PassiveResource) EMFLoadHelper.loadAndResolveEObject(resourceURI);
+        IPassiveResource pr = assemblyPassiveResourceHash.get(assemblyContext.getId() + resource.getId());
+
+        if (pr == null) {
+            pr = ((SimulatedResourceContainer) resourceContainer).createPassiveResource(resource, assemblyContext,
+                    capacity);
+            assemblyPassiveResourceHash.put(assemblyContext.getId() + resource.getId(), pr);
+        }
+
+        return pr;
+    }
+
+	/**
+	 * Template method to be filled in by the generator. Calles
+	 * linkAssemblyContextAndResourceContainer to create the deployment specified in
+	 * the allocation model
+	 */
+	protected abstract void initialiseAssemblyContextLookup();
+	
+	@Override
+	public IAssemblyAllocationLookup<AbstractSimulatedResourceContainer> getAssemblyAllocationLookup() {
+		return assemblyLinkLookup;
+	}
+}

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/fork/ForkContext.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/fork/ForkContext.java
@@ -3,6 +3,7 @@ package de.uka.ipd.sdq.simucomframework.fork;
 import de.uka.ipd.sdq.simucomframework.Context;
 import de.uka.ipd.sdq.simucomframework.SimuComSimProcess;
 import de.uka.ipd.sdq.simucomframework.resources.AbstractSimulatedResourceContainer;
+import de.uka.ipd.sdq.simucomframework.resources.IAssemblyAllocationLookup;
 import de.uka.ipd.sdq.simucomframework.variables.stackframe.SimulatedStack;
 
 /**
@@ -40,19 +41,13 @@ public class ForkContext extends Context {
      */
     private static final long serialVersionUID = 6701742993106975705L;
 
-    @Override
-    public AbstractSimulatedResourceContainer findResource(final String assemblyContextID) {
-        // Use my parents allocation information to do my look ups
-        return parentContext.findResource(assemblyContextID);
-    }
-
     public Context getParentContext() {
         return parentContext;
     }
 
-    @Override
-    protected void initialiseAssemblyContextLookup() {
-        // Emtpy as we use our parents allocation lookup
-    }
+	@Override
+	public IAssemblyAllocationLookup<AbstractSimulatedResourceContainer> getAssemblyAllocationLookup() {
+		return getParentContext().getAssemblyAllocationLookup();
+	}
 
 }

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/fork/ForkContext.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/fork/ForkContext.java
@@ -19,11 +19,9 @@ public class ForkContext extends Context {
     /**
      * Constructor of the parallel process
      * 
-     * @param parentContext
-     *            The current context of the parent thread. Used to evaluate variables in the
-     *            parallel process
-     * @param parent
-     *            The parent process
+     * @param parentContext The current context of the parent thread. Used to
+     *                      evaluate variables in the parallel process
+     * @param parent        The parent process
      */
     public ForkContext(final Context parentContext, final SimuComSimProcess parent) {
         super(parentContext.getModel());
@@ -45,9 +43,9 @@ public class ForkContext extends Context {
         return parentContext;
     }
 
-	@Override
-	public IAssemblyAllocationLookup<AbstractSimulatedResourceContainer> getAssemblyAllocationLookup() {
-		return getParentContext().getAssemblyAllocationLookup();
-	}
+    @Override
+    public IAssemblyAllocationLookup<AbstractSimulatedResourceContainer> getAssemblyAllocationLookup() {
+        return getParentContext().getAssemblyAllocationLookup();
+    }
 
 }

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/HashMapAssemblyAllocationLookup.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/HashMapAssemblyAllocationLookup.java
@@ -1,0 +1,28 @@
+package de.uka.ipd.sdq.simucomframework.resources;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Provides a simple implementation of the interface based on HashMap. The
+ * HashMap itself needs to be kept externally in order to provide editing
+ * support.
+ */
+public class HashMapAssemblyAllocationLookup<AllocationType> implements IAssemblyAllocationLookup<AllocationType> {
+    protected final Map<String, AllocationType> internalMap;
+
+    /**
+     * {@inheritDoc}
+     */
+    public HashMapAssemblyAllocationLookup(Map<String, AllocationType> delegateMap) {
+        internalMap = Collections.unmodifiableMap(delegateMap);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AllocationType getAllocatedEntity(String assemblyContextId) {
+        return internalMap.get(assemblyContextId);
+    }
+}

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/IAssemblyAllocationLookup.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/IAssemblyAllocationLookup.java
@@ -1,0 +1,59 @@
+package de.uka.ipd.sdq.simucomframework.resources;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.palladiosimulator.pcm.core.composition.AssemblyContext;
+
+/**
+ * Through the IAssemblyAllocationLookup interface it is possible to access the
+ * current allocations of assembly contexts to resource containers.
+ * 
+ * The interface has been introduced to account for SimuLizar's dynamic nature
+ * with allocations being created or changed during simulation time.
+ * 
+ * Furthermore, this interfaces allows for multiple contexts to share the same
+ * lookup information.
+ * 
+ * @author Sebastian Krach
+ *
+ */
+public interface IAssemblyAllocationLookup<AllocationType> {
+
+	/**
+	 * Provides a simple implementation of the interface based on HashMap. The
+	 * HashMap itself needs to be kept externally in order to provide editing
+	 * support.
+	 */
+	public class HashMapAssemblyAllocationLookup<AllocationType> implements IAssemblyAllocationLookup<AllocationType> {
+		protected final Map<String, AllocationType> internalMap;
+
+		public HashMapAssemblyAllocationLookup(Map<String, AllocationType> delegateMap) {
+			internalMap = Collections.unmodifiableMap(delegateMap);
+		}
+
+		@Override
+		public AllocationType getAllocatedEntity(String assemblyContextId) {
+			return internalMap.get(assemblyContextId);
+		}
+	}
+
+	/**
+	 * Get the entity to which the assembly context identified by the provided ID is
+	 * allocated to.
+	 * 
+	 * @param assemblyContextId The UUID of the assembly context
+	 * @return the entity
+	 */
+	AllocationType getAllocatedEntity(String assemblyContextId);
+
+	/**
+	 * Get the entity to which the provided assembly context is allocated to.
+	 * 
+	 * @param context the assembly context
+	 * @return the entity
+	 */
+	default AllocationType getAllocatedEntity(AssemblyContext context) {
+		return getAllocatedEntity(context.getId());
+	}
+}

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/IAssemblyAllocationLookup.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/IAssemblyAllocationLookup.java
@@ -1,8 +1,5 @@
 package de.uka.ipd.sdq.simucomframework.resources;
 
-import java.util.Collections;
-import java.util.Map;
-
 import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 
 /**
@@ -12,31 +9,13 @@ import org.palladiosimulator.pcm.core.composition.AssemblyContext;
  * The interface has been introduced to account for SimuLizar's dynamic nature
  * with allocations being created or changed during simulation time.
  * 
- * Furthermore, this interfaces allows for multiple contexts to share the same
+ * Furthermore, this interface allows for multiple contexts to share the same
  * lookup information.
  * 
  * @author Sebastian Krach
  *
  */
 public interface IAssemblyAllocationLookup<AllocationType> {
-
-    /**
-     * Provides a simple implementation of the interface based on HashMap. The
-     * HashMap itself needs to be kept externally in order to provide editing
-     * support.
-     */
-    public class HashMapAssemblyAllocationLookup<AllocationType> implements IAssemblyAllocationLookup<AllocationType> {
-        protected final Map<String, AllocationType> internalMap;
-
-        public HashMapAssemblyAllocationLookup(Map<String, AllocationType> delegateMap) {
-            internalMap = Collections.unmodifiableMap(delegateMap);
-        }
-
-        @Override
-        public AllocationType getAllocatedEntity(String assemblyContextId) {
-            return internalMap.get(assemblyContextId);
-        }
-    }
 
     /**
      * Get the entity to which the assembly context identified by the provided ID is

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/IAssemblyAllocationLookup.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/IAssemblyAllocationLookup.java
@@ -20,40 +20,40 @@ import org.palladiosimulator.pcm.core.composition.AssemblyContext;
  */
 public interface IAssemblyAllocationLookup<AllocationType> {
 
-	/**
-	 * Provides a simple implementation of the interface based on HashMap. The
-	 * HashMap itself needs to be kept externally in order to provide editing
-	 * support.
-	 */
-	public class HashMapAssemblyAllocationLookup<AllocationType> implements IAssemblyAllocationLookup<AllocationType> {
-		protected final Map<String, AllocationType> internalMap;
+    /**
+     * Provides a simple implementation of the interface based on HashMap. The
+     * HashMap itself needs to be kept externally in order to provide editing
+     * support.
+     */
+    public class HashMapAssemblyAllocationLookup<AllocationType> implements IAssemblyAllocationLookup<AllocationType> {
+        protected final Map<String, AllocationType> internalMap;
 
-		public HashMapAssemblyAllocationLookup(Map<String, AllocationType> delegateMap) {
-			internalMap = Collections.unmodifiableMap(delegateMap);
-		}
+        public HashMapAssemblyAllocationLookup(Map<String, AllocationType> delegateMap) {
+            internalMap = Collections.unmodifiableMap(delegateMap);
+        }
 
-		@Override
-		public AllocationType getAllocatedEntity(String assemblyContextId) {
-			return internalMap.get(assemblyContextId);
-		}
-	}
+        @Override
+        public AllocationType getAllocatedEntity(String assemblyContextId) {
+            return internalMap.get(assemblyContextId);
+        }
+    }
 
-	/**
-	 * Get the entity to which the assembly context identified by the provided ID is
-	 * allocated to.
-	 * 
-	 * @param assemblyContextId The UUID of the assembly context
-	 * @return the entity
-	 */
-	AllocationType getAllocatedEntity(String assemblyContextId);
+    /**
+     * Get the entity to which the assembly context identified by the provided ID is
+     * allocated to.
+     * 
+     * @param assemblyContextId The UUID of the assembly context
+     * @return the entity
+     */
+    AllocationType getAllocatedEntity(String assemblyContextId);
 
-	/**
-	 * Get the entity to which the provided assembly context is allocated to.
-	 * 
-	 * @param context the assembly context
-	 * @return the entity
-	 */
-	default AllocationType getAllocatedEntity(AssemblyContext context) {
-		return getAllocatedEntity(context.getId());
-	}
+    /**
+     * Get the entity to which the provided assembly context is allocated to.
+     * 
+     * @param context the assembly context
+     * @return the entity
+     */
+    default AllocationType getAllocatedEntity(AssemblyContext context) {
+        return getAllocatedEntity(context.getId());
+    }
 }

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/ISimulatedModelEntityAccess.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/ISimulatedModelEntityAccess.java
@@ -3,8 +3,9 @@ package de.uka.ipd.sdq.simucomframework.resources;
 import de.uka.ipd.sdq.identifier.Identifier;
 
 /**
- * Through the ISimulatedModelEntityAccess interface it is possible to access the
- * current simulation entity responsible for a particular entity of the model.
+ * Through the ISimulatedModelEntityAccess interface it is possible to access
+ * the current simulation entity responsible for a particular entity of the
+ * model.
  * 
  * Furthermore, this interfaces allows for multiple contexts to share the same
  * lookup information.
@@ -14,11 +15,17 @@ import de.uka.ipd.sdq.identifier.Identifier;
  */
 @FunctionalInterface
 public interface ISimulatedModelEntityAccess<ModelEntity extends Identifier, SimulatedModelEntityType> {
-	
-	SimulatedModelEntityType getSimulatedEntity(String modelEntityIdentifier);
-	
-	default SimulatedModelEntityType getSimulatedEntity(ModelEntity modelEntity) {
-		return getSimulatedEntity(modelEntity.getId());
-	}
+
+    /**
+     * Gets the simulation entitiy for the model entity identified by the provided id.
+     */
+    SimulatedModelEntityType getSimulatedEntity(String modelEntityIdentifier);
+
+    /**
+     * Gets the simulation entitiy for the model entity.
+     */
+    default SimulatedModelEntityType getSimulatedEntity(ModelEntity modelEntity) {
+        return getSimulatedEntity(modelEntity.getId());
+    }
 
 }

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/ISimulatedModelEntityAccess.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/ISimulatedModelEntityAccess.java
@@ -1,0 +1,24 @@
+package de.uka.ipd.sdq.simucomframework.resources;
+
+import de.uka.ipd.sdq.identifier.Identifier;
+
+/**
+ * Through the ISimulatedModelEntityAccess interface it is possible to access the
+ * current simulation entity responsible for a particular entity of the model.
+ * 
+ * Furthermore, this interfaces allows for multiple contexts to share the same
+ * lookup information.
+ * 
+ * @author Sebastian Krach
+ *
+ */
+@FunctionalInterface
+public interface ISimulatedModelEntityAccess<ModelEntity extends Identifier, SimulatedModelEntityType> {
+	
+	SimulatedModelEntityType getSimulatedEntity(String modelEntityIdentifier);
+	
+	default SimulatedModelEntityType getSimulatedEntity(ModelEntity modelEntity) {
+		return getSimulatedEntity(modelEntity.getId());
+	}
+
+}

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/ISimulatedModelEntityAccess.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/ISimulatedModelEntityAccess.java
@@ -17,12 +17,12 @@ import de.uka.ipd.sdq.identifier.Identifier;
 public interface ISimulatedModelEntityAccess<ModelEntity extends Identifier, SimulatedModelEntityType> {
 
     /**
-     * Gets the simulation entitiy for the model entity identified by the provided id.
+     * Gets the simulation entity for the model entity identified by the provided id.
      */
     SimulatedModelEntityType getSimulatedEntity(String modelEntityIdentifier);
 
     /**
-     * Gets the simulation entitiy for the model entity.
+     * Gets the simulation entity for the model entity.
      */
     default SimulatedModelEntityType getSimulatedEntity(ModelEntity modelEntity) {
         return getSimulatedEntity(modelEntity.getId());

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/SimulatedLinkingResource.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/SimulatedLinkingResource.java
@@ -4,8 +4,8 @@ import java.io.Serializable;
 import java.util.Map;
 
 import org.apache.log4j.Logger;
-
 import org.palladiosimulator.pcm.resourceenvironment.LinkingResource;
+
 import de.uka.ipd.sdq.scheduler.IActiveResource;
 import de.uka.ipd.sdq.simucomframework.SimuComSimProcess;
 import de.uka.ipd.sdq.simucomframework.exceptions.FailureException;
@@ -28,8 +28,8 @@ public class SimulatedLinkingResource extends AbstractScheduledResource {
     private static long resourceId = 1;
 
     private final LinkingResource linkingResource;
-    private final String throughput;
-    private final String latencySpec;
+    private String throughput;
+    private String latencySpec;
 
     // For resources that can fail (SimulatedLinkingResources):
     private final boolean canFail;
@@ -173,5 +173,23 @@ public class SimulatedLinkingResource extends AbstractScheduledResource {
 
     public LinkingResource getLinkingResource() {
         return this.linkingResource;
+    }
+
+    /**
+     * Change the linking resource throughput after its creation.
+     * 
+     * @param throughput the new throughput specification
+     */
+    public void setThroughput(String throughput) {
+        this.throughput = throughput;
+    }
+
+    /**
+     * Change the linking resource latency after its creation.
+     * 
+     * @param latency the new latency specification
+     */
+    public void setLatency(String latency) {
+        this.latencySpec = latency;
     }
 }


### PR DESCRIPTION
This pull request factors out some SimuCom specific context functionality which does not work for SimuLizar into a dedicated class (SimuComContext).

The functionality to lookup SimulatedResourceContainers based on the AssemblyContext has been pulled into a dedicated interface which is implemented in a trivial manner for SimuCom (HashMap as before). For SimuLizar this allows us to provide a more elaborate mechanism which takes reconfigurations into account.
