### PR TITLE
SIMUCOM-11 Build unique allocation context name

### DIFF
--- a/bundles/de.uka.ipd.sdq.codegen.simucontroller/src/de/uka/ipd/sdq/pcm/transformations/ApplyConnectorCompletionsJob.java
+++ b/bundles/de.uka.ipd.sdq.codegen.simucontroller/src/de/uka/ipd/sdq/pcm/transformations/ApplyConnectorCompletionsJob.java
@@ -140,7 +140,7 @@ public class ApplyConnectorCompletionsJob implements IBlackboardInteractingJob<M
 
         models.getSystem().getAssemblyContexts__ComposedStructure().add(ctx);
         AllocationContext allocCtx = AllocationFactory.eINSTANCE.createAllocationContext();
-        allocCtx.setEntityName("AllocCtx Middleware " + resContainer.getEntityName() + resContainer.getId());
+        allocCtx.setEntityName("AllocCtx Middleware " + resContainer.getEntityName() + " " + resContainer.getId());
         allocCtx.setAssemblyContext_AllocationContext(ctx);
         allocCtx.setResourceContainer_AllocationContext(resContainer);
         models.getAllocation().getAllocationContexts_Allocation().add(allocCtx);

--- a/bundles/de.uka.ipd.sdq.codegen.simucontroller/src/de/uka/ipd/sdq/pcm/transformations/ApplyConnectorCompletionsJob.java
+++ b/bundles/de.uka.ipd.sdq.codegen.simucontroller/src/de/uka/ipd/sdq/pcm/transformations/ApplyConnectorCompletionsJob.java
@@ -133,14 +133,14 @@ public class ApplyConnectorCompletionsJob implements IBlackboardInteractingJob<M
      */
     private void addMiddleware(PCMAndCompletionModelHolder models, ResourceContainer resContainer) {
         AssemblyContext ctx = CompositionFactory.eINSTANCE.createAssemblyContext();
-        ctx.setEntityName("AssCtx Middleware " + resContainer.getEntityName());
+        ctx.setEntityName("AssCtx Middleware " + resContainer.getEntityName() + " " + resContainer.getId());
         ctx.setEncapsulatedComponent__AssemblyContext(models.getMiddlewareRepository().getComponents__Repository()
                 .get(0)); // TODO: Parameterise me!
         models.getSystem().getAssemblyContexts__ComposedStructure().add(ctx);
 
         models.getSystem().getAssemblyContexts__ComposedStructure().add(ctx);
         AllocationContext allocCtx = AllocationFactory.eINSTANCE.createAllocationContext();
-        allocCtx.setEntityName("AllocCtx Middleware " + resContainer.getEntityName());
+        allocCtx.setEntityName("AllocCtx Middleware " + resContainer.getEntityName() + resContainer.getId());
         allocCtx.setAssemblyContext_AllocationContext(ctx);
         allocCtx.setResourceContainer_AllocationContext(resContainer);
         models.getAllocation().getAllocationContexts_Allocation().add(allocCtx);
@@ -148,7 +148,7 @@ public class ApplyConnectorCompletionsJob implements IBlackboardInteractingJob<M
         if (LOGGER.isEnabledFor(Level.INFO)) {
             LOGGER.info("Added middleware component >"
                     + ctx.getEncapsulatedComponent__AssemblyContext().getEntityName() + "< to resource container >"
-                    + resContainer.getEntityName() + "<");
+                    + resContainer.getEntityName() + " (" + resContainer.getId() + ")" + "<");
         }
     }
 


### PR DESCRIPTION
This PR addresses [SIMUCOM-11](https://jira.palladio-simulator.com/browse/SIMUCOM-11).

The code generation uses the name of the allocation context to derive a name in the source code. If the name is not unique within a system, the code cannot be compiled. Adding the ID of the resource container to the name circumvents this issue.

I could not reproduce the problem mentioned in the issue anymore. However, there might be other places where this issue is not correctly reflected. Because SimuCom is deprecated, I do not think that we should investigate this issue in more detail.