### PR TITLE
[Simulizar-115] Added support for nested assembly contexts

### DIFF
--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/IAssemblyAllocationLookup.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/IAssemblyAllocationLookup.java
@@ -56,8 +56,8 @@ public interface IAssemblyAllocationLookup<AllocationType> {
      */
     default AllocationType getAllocatedEntity(List<AssemblyContext> contextHierarchy) {
         return getAllocatedEntity(contextHierarchy.stream()
-                                                  .map(Identifier::getId)
-                                                  .collect(Collectors.joining("::")));
+            .map(Identifier::getId)
+            .collect(Collectors.joining("::")));
     }
 
 }

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/IAssemblyAllocationLookup.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/IAssemblyAllocationLookup.java
@@ -1,6 +1,6 @@
 package de.uka.ipd.sdq.simucomframework.resources;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.palladiosimulator.pcm.core.composition.AssemblyContext;
@@ -9,14 +9,13 @@ import org.palladiosimulator.pcm.repository.BasicComponent;
 import de.uka.ipd.sdq.identifier.Identifier;
 
 /**
- * Through the IAssemblyAllocationLookup interface it is possible to access the
- * current allocations of assembly contexts to resource containers.
+ * Through the IAssemblyAllocationLookup interface it is possible to access the current allocations
+ * of assembly contexts to resource containers.
  * 
- * The interface has been introduced to account for SimuLizar's dynamic nature
- * with allocations being created or changed during simulation time.
+ * The interface has been introduced to account for SimuLizar's dynamic nature with allocations
+ * being created or changed during simulation time.
  * 
- * Furthermore, this interface allows for multiple contexts to share the same
- * lookup information.
+ * Furthermore, this interface allows for multiple contexts to share the same lookup information.
  * 
  * @author Sebastian Krach
  *
@@ -24,10 +23,10 @@ import de.uka.ipd.sdq.identifier.Identifier;
 public interface IAssemblyAllocationLookup<AllocationType> {
 
     /**
-     * Get the entity to which the assembly context identified by the provided ID is
-     * allocated to.
+     * Get the entity to which the assembly context identified by the provided ID is allocated to.
      * 
-     * @param assemblyContextId The UUID of the assembly context
+     * @param assemblyContextId
+     *            The UUID of the assembly context
      * @return the entity
      */
     AllocationType getAllocatedEntity(String assemblyContextId);
@@ -35,7 +34,8 @@ public interface IAssemblyAllocationLookup<AllocationType> {
     /**
      * Get the entity to which the provided assembly context is allocated to.
      * 
-     * @param context the assembly context
+     * @param context
+     *            the assembly context
      * @return the entity
      */
     default AllocationType getAllocatedEntity(AssemblyContext context) {
@@ -47,15 +47,17 @@ public interface IAssemblyAllocationLookup<AllocationType> {
     }
 
     /**
-     * Get the entity to which the provided assembly context within its hierarchical
-     * context is allocated to.
+     * Get the entity to which the provided assembly context within its hierarchical context is
+     * allocated to.
      * 
-     * @param contextHierarchy the hierarchy of assembly contexts of component
-     *                         compositions
+     * @param contextHierarchy
+     *            the hierarchy of assembly contexts of component compositions
      * @return the entity
      */
-    default AllocationType getAllocatedEntity(Collection<AssemblyContext> contextHierarchy) {
-        return getAllocatedEntity(contextHierarchy.stream().map(Identifier::getId).collect(Collectors.joining("::")));
+    default AllocationType getAllocatedEntity(List<AssemblyContext> contextHierarchy) {
+        return getAllocatedEntity(contextHierarchy.stream()
+                                                  .map(Identifier::getId)
+                                                  .collect(Collectors.joining("::")));
     }
 
 }

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/IAssemblyAllocationLookup.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/IAssemblyAllocationLookup.java
@@ -1,6 +1,12 @@
 package de.uka.ipd.sdq.simucomframework.resources;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
+
 import org.palladiosimulator.pcm.core.composition.AssemblyContext;
+import org.palladiosimulator.pcm.repository.BasicComponent;
+
+import de.uka.ipd.sdq.identifier.Identifier;
 
 /**
  * Through the IAssemblyAllocationLookup interface it is possible to access the
@@ -33,6 +39,23 @@ public interface IAssemblyAllocationLookup<AllocationType> {
      * @return the entity
      */
     default AllocationType getAllocatedEntity(AssemblyContext context) {
+        if (context.getParentStructure__AssemblyContext() instanceof BasicComponent) {
+            throw new IllegalArgumentException("Only root assembly contexts can be allocated directly. "
+                    + "Please use getAllocatedEntity(Stack<AssemblyContext>).");
+        }
         return getAllocatedEntity(context.getId());
     }
+
+    /**
+     * Get the entity to which the provided assembly context within its hierarchical
+     * context is allocated to.
+     * 
+     * @param contextHierarchy the hierarchy of assembly contexts of component
+     *                         compositions
+     * @return the entity
+     */
+    default AllocationType getAllocatedEntity(Collection<AssemblyContext> contextHierarchy) {
+        return getAllocatedEntity(contextHierarchy.stream().map(Identifier::getId).collect(Collectors.joining("::")));
+    }
+
 }


### PR DESCRIPTION
Introduce support looking up allocations for nested assembly contexts. Assemblies are differentiated by a composition of the if of the assembly context in question with the ids of the enclosing assemblies. 

Note: We currently do not support subsystem deployments across multiple resource containers. Hence, the allocation of a nested assembly is always the same as the outermost enclosing assembly. Nevertheless, this is no restriction of the interface, but an implementation detail.