### PR TITLE
Support for adding links without calculators

### DIFF
--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/SimulatedLinkingResourceContainer.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/SimulatedLinkingResourceContainer.java
@@ -21,16 +21,23 @@ public class SimulatedLinkingResourceContainer extends AbstractSimulatedResource
         super(myModel, id);
     }
 
-    public void addActiveResource(LinkingResource linkingResource, final String resourceContainerID) {
+    public SimulatedLinkingResource addActiveResourceWithoutCalculators(LinkingResource linkingResource,
+            final String resourceContainerID) {
         final SimulatedLinkingResource r = new SimulatedLinkingResource(linkingResource, myModel, resourceContainerID);
         activeResources.put(linkingResource.getCommunicationLinkResourceSpecifications_LinkingResource()
-                .getCommunicationLinkResourceType_CommunicationLinkResourceSpecification().getId(), r);
+            .getCommunicationLinkResourceType_CommunicationLinkResourceSpecification()
+            .getId(), r);
+        return r;
+    }
+
+    public void addActiveResource(LinkingResource linkingResource, final String resourceContainerID) {
+        var resource = addActiveResourceWithoutCalculators(linkingResource, resourceContainerID);
 
         // setup calculators
         // TODO: setup waiting time calculator
         // CalculatorHelper.setupWaitingTimeCalculator(r);
-        CalculatorHelper.setupDemandCalculator(r, this.myModel);
-        CalculatorHelper.setupActiveResourceStateCalculators(r, this.myModel);
+        CalculatorHelper.setupDemandCalculator(resource, this.myModel);
+        CalculatorHelper.setupActiveResourceStateCalculators(resource, this.myModel);
     }
 
     /**


### PR DESCRIPTION
Added a method to add a SimulatedLinkingResource to a SimulatedLinkingResourceContainer without triggering Calculator/Monitor creation. SimuLizar manages calculators based on the dedicated MonitorRepository. This change just splits a method into two, similar to `addActiveResourceWithoutCalculator` in SimulatedResourceContainer (for ProcessingResources).

In general the creation of monitors should be factored out of the simulation instances. Follow up issue: https://jira.palladio-simulator.com/browse/SIMUCOM-94