### PR TITLE
[QUAL-45] Quick fix for utilization calculator

### DIFF
--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/CalculatorHelper.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/CalculatorHelper.java
@@ -23,6 +23,7 @@ import org.palladiosimulator.pcmmeasuringpoint.LinkingResourceMeasuringPoint;
 import org.palladiosimulator.pcmmeasuringpoint.PcmmeasuringpointFactory;
 import org.palladiosimulator.probeframework.ProbeFrameworkContext;
 import org.palladiosimulator.probeframework.calculator.Calculator;
+import org.palladiosimulator.probeframework.calculator.DefaultCalculatorProbeSets;
 import org.palladiosimulator.probeframework.measurement.RequestContext;
 import org.palladiosimulator.probeframework.probes.EventProbe;
 import org.palladiosimulator.probeframework.probes.EventProbeList;
@@ -287,8 +288,10 @@ public final class CalculatorHelper {
             }
 
         });
-        return model.getProbeFrameworkContext().getCalculatorFactory()
-                .buildOverallStateOfActiveResourceCalculator(measuringPoint, scheduledResourceProbe);
+        return model.getProbeFrameworkContext()
+            .getGenericCalculatorFactory()
+            .buildCalculator(scheduledResourceProbe.getMetricDesciption(), measuringPoint,
+                    DefaultCalculatorProbeSets.createSingularProbeConfiguration(scheduledResourceProbe));
     }
 
     /**


### PR DESCRIPTION
Quick fix for https://jira.palladio-simulator.com/browse/QUAL-45.

Before a Identity calculator was created for the OverallStateOfActiveResource metric but fed by a Utilization of Active Resource Probe. Now, the calculator is created for the correct metric.