### PR TITLE
Jira issue PALLADIO-457

### DIFF
--- a/bundles/de.uka.ipd.sdq.codegen.simucontroller/plugin.xml
+++ b/bundles/de.uka.ipd.sdq.codegen.simucontroller/plugin.xml
@@ -4,7 +4,7 @@
    <extension-point id="de.uka.ipd.sdq.codegen.simucontroller.simulator" name="Palladio Simulator" schema="schema/de.uka.ipd.sdq.codegen.simucontroller.simulator.exsd"/>
 	<extension point="org.eclipse.debug.core.launchConfigurationTypes">
 	    <launchConfigurationType
-           delegate="de.uka.ipd.sdq.codegen.simucontroller.runconfig.SimulationWorkflowLauncher"
+           delegate="de.uka.ipd.sdq.codegen.simucontroller.runconfig.SimuComWorkflowLauncher"
            id="de.uka.ipd.sdq.simucontroller.SimuLaunching"
            modes="run, debug"
            name="SimuBench"

--- a/bundles/de.uka.ipd.sdq.codegen.simucontroller/src/de/uka/ipd/sdq/codegen/simucontroller/runconfig/SimuComWorkflowLauncher.java
+++ b/bundles/de.uka.ipd.sdq.codegen.simucontroller/src/de/uka/ipd/sdq/codegen/simucontroller/runconfig/SimuComWorkflowLauncher.java
@@ -32,7 +32,7 @@ public class SimuComWorkflowLauncher extends AbstractPCMLaunchConfigurationDeleg
     @Override
     protected SimuComWorkflowConfiguration deriveConfiguration(ILaunchConfiguration configuration, String mode)
             throws CoreException {
-        SimuComWorkflowConfiguration config = new SimuComWorkflowConfiguration(configuration.getAttributes());
+    	SimuComWorkflowConfiguration config = new SimuComWorkflowConfiguration(configuration.getAttributes());
 
         AbstractWorkflowConfigurationBuilder builder;
         builder = new PCMWorkflowConfigurationBuilder(configuration, mode);

--- a/bundles/de.uka.ipd.sdq.simucom.rerunsimulation/src/de/uka/ipd/sdq/simucom/rerunsimulation/runconfig/RerunSimuComConfigurationTab.java
+++ b/bundles/de.uka.ipd.sdq.simucom.rerunsimulation/src/de/uka/ipd/sdq/simucom/rerunsimulation/runconfig/RerunSimuComConfigurationTab.java
@@ -1,11 +1,8 @@
 package de.uka.ipd.sdq.simucom.rerunsimulation.runconfig;
 
-import org.eclipse.debug.core.ILaunchConfiguration;
-import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.ui.ILaunchConfigurationTab;
 
 import de.uka.ipd.sdq.codegen.simucontroller.runconfig.SimuComConfigurationTab;
-import de.uka.ipd.sdq.simulation.AbstractSimulationConfig;
 
 /**
  * This tab is basically the same tab as SimuComConfigurationTab. The only difference is that in
@@ -17,24 +14,4 @@ import de.uka.ipd.sdq.simulation.AbstractSimulationConfig;
  */
 public class RerunSimuComConfigurationTab extends SimuComConfigurationTab implements ILaunchConfigurationTab {
 
-    @Override
-    protected void createSimulatorGroup() {
-        // Do nothing here
-    }
-
-    @Override
-    protected void initializeSimulatorGroup(ILaunchConfiguration configuration) {
-        // Do nothing here
-    }
-
-    @Override
-    protected void applySimulatorGroup(ILaunchConfigurationWorkingCopy configuration) {
-        configuration
-                .setAttribute(AbstractSimulationConfig.SIMULATOR_ID, AbstractSimulationConfig.DEFAULT_SIMULATOR_ID);
-    }
-
-    @Override
-    protected boolean isSimulatorGroupValid() {
-        return true;
-    }
 }


### PR DESCRIPTION
Deleting the simulation group from SimuCom configuration tab and change the UI launch delegate to start directly the simucom workflow launcher. In this way, no further simulators (like SimuLizar) are loaded and the corresponding simulator of each launch configuration is called directly.