### PR TITLE
[SIMULIZAR-118] Adapt network completion support

### DIFF
--- a/bundles/de.uka.ipd.sdq.codegen.simucontroller/src/de/uka/ipd/sdq/pcm/transformations/builder/abstractbuilder/BasicComponentBuilder.java
+++ b/bundles/de.uka.ipd.sdq.codegen.simucontroller/src/de/uka/ipd/sdq/pcm/transformations/builder/abstractbuilder/BasicComponentBuilder.java
@@ -2,6 +2,7 @@ package de.uka.ipd.sdq.pcm.transformations.builder.abstractbuilder;
 
 import org.palladiosimulator.pcm.allocation.AllocationContext;
 import org.palladiosimulator.pcm.allocation.AllocationFactory;
+import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.pcm.core.composition.CompositionFactory;
 import org.palladiosimulator.pcm.repository.BasicComponent;
 import org.palladiosimulator.pcm.repository.OperationInterface;
@@ -57,11 +58,15 @@ public abstract class BasicComponentBuilder extends AbstractComponentBuilder {
         this.myAssemblyContext.setEntityName("BCAssembly " + myComponent.getEntityName());
         this.myAssemblyContext.setEncapsulatedComponent__AssemblyContext(myComponent);
 
-        this.myAllocationContext = AllocationFactory.eINSTANCE.createAllocationContext();
-        myAllocationContext.setAssemblyContext_AllocationContext(myAssemblyContext);
-        myAllocationContext.setResourceContainer_AllocationContext(this.container);
-
+        this.myAllocationContext = createAllocationContext(myAssemblyContext);
         myModels.getAllocation().getAllocationContexts_Allocation().add(myAllocationContext);
+    }
+    
+    protected AllocationContext createAllocationContext(AssemblyContext assembly) {
+        var result = AllocationFactory.eINSTANCE.createAllocationContext();
+        result.setAssemblyContext_AllocationContext(assembly);
+        result.setResourceContainer_AllocationContext(this.container);
+        return result;
     }
 
     protected BasicComponent getBasicComponent() {

--- a/bundles/de.uka.ipd.sdq.codegen.simucontroller/src/de/uka/ipd/sdq/pcm/transformations/builder/resourceconsumer/NetworkLoadingComponentBuilder.java
+++ b/bundles/de.uka.ipd.sdq.codegen.simucontroller/src/de/uka/ipd/sdq/pcm/transformations/builder/resourceconsumer/NetworkLoadingComponentBuilder.java
@@ -2,10 +2,11 @@ package de.uka.ipd.sdq.pcm.transformations.builder.resourceconsumer;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.palladiosimulator.analyzer.completions.CompletionsFactory;
+import org.palladiosimulator.pcm.allocation.AllocationContext;
+import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.pcm.repository.OperationInterface;
 import org.palladiosimulator.pcm.resourceenvironment.LinkingResource;
-import org.palladiosimulator.pcm.resourceenvironment.ResourceContainer;
-import org.palladiosimulator.pcm.resourceenvironment.ResourceenvironmentFactory;
 import org.palladiosimulator.pcm.resourcetype.CommunicationLinkResourceType;
 
 import de.uka.ipd.sdq.pcm.transformations.builder.abstractbuilder.BasicComponentBuilder;
@@ -25,6 +26,7 @@ public class NetworkLoadingComponentBuilder extends BasicComponentBuilder {
 
     private final Logger logger = Logger.getLogger(NetworkLoadingComponentBuilder.class);
     private final CommunicationLinkResourceType typeOfLink;
+    private final LinkingResource link;
 
     /**
      * Constructor of the network load simulator component
@@ -40,12 +42,17 @@ public class NetworkLoadingComponentBuilder extends BasicComponentBuilder {
             final LinkingResource linkingRes) {
         super(models, interf, null, "NetworkLoadingComponent");
 
+        link = linkingRes;
         typeOfLink = linkingRes.getCommunicationLinkResourceSpecifications_LinkingResource()
                 .getCommunicationLinkResourceType_CommunicationLinkResourceSpecification();
-        final ResourceContainer dummyContainer = ResourceenvironmentFactory.eINSTANCE.createResourceContainer();
-        dummyContainer.setId(linkingRes.getId());
-
-        this.container = dummyContainer;
+    }
+    
+    @Override
+    protected AllocationContext createAllocationContext(AssemblyContext assembly) {
+        var allocationCtx = CompletionsFactory.eINSTANCE.createNetworkComponentAllocationContext();
+        allocationCtx.setAssemblyContext_AllocationContext(assembly);
+        allocationCtx.setLinkingResource(link);
+        return allocationCtx;
     }
 
     /**

--- a/bundles/de.uka.ipd.sdq.pcm.codegen.simucom/src-transforms/de/uka/ipd/sdq/pcm/codegen/simucom/transformations/sim/SimAllocationXpt.xtend
+++ b/bundles/de.uka.ipd.sdq.pcm.codegen.simucom/src-transforms/de/uka/ipd/sdq/pcm/codegen/simucom/transformations/sim/SimAllocationXpt.xtend
@@ -14,6 +14,7 @@ import org.palladiosimulator.pcm.system.System
 import org.palladiosimulator.analyzer.completions.Completion
 import org.palladiosimulator.pcm.core.entity.ComposedProvidingRequiringEntity
 import org.palladiosimulator.pcm.core.composition.ComposedStructure
+import org.palladiosimulator.analyzer.completions.NetworkComponentAllocationContext
 
 class SimAllocationXpt extends AllocationXpt {
 	@Inject extension M2TFileSystemAccess fsa
@@ -72,7 +73,11 @@ class SimAllocationXpt extends AllocationXpt {
 			else
 				context.assemblyContext_AllocationContext.id
 		»
+		«IF (context instanceof NetworkComponentAllocationContext)»
+		linkAssemblyContextAndResourceContainer("«fullAssemblyContextID»","«context.linkingResource.id»");
+		«ELSE»
 		linkAssemblyContextAndResourceContainer("«fullAssemblyContextID»","«context.resourceContainer_AllocationContext.id»");
+		«ENDIF»
 		
 		
 		«IF (context.assemblyContext_AllocationContext.encapsulatedComponent__AssemblyContext instanceof CompositeComponent) 


### PR DESCRIPTION
Adapted initialization to use the new NetworkComponentAssemblyContext, to prevent the creation of uncontained dummy ResourceContainers.

This change depends on PalladioSimulator/Palladio-Analyzer-Framework#10.