### PR TITLE
Relaxed ties between SimuCom and SimuLizar

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
 PalladioPipeline {
     deployUpdatesite 'releng/org.palladiosimulator.simucom.updatesite/target/repository'
+    skipDeploy false
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,3 @@
 PalladioPipeline {
     deployUpdatesite 'releng/org.palladiosimulator.simucom.updatesite/target/repository'
-    skipDeploy false
 }

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/SimuComConfig.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/SimuComConfig.java
@@ -63,7 +63,7 @@ public class SimuComConfig extends AbstractSimulationConfig implements Serializa
 
     // SimuCom extensions can also provide extension to the SimuCom configuration.
     // This map stores the extension configurations.
-    private HashMap<String, SimuComConfigExtension> simuComConfigExtensions;
+    private final HashMap<String, SimuComConfigExtension> simuComConfigExtensions = new HashMap<String, SimuComConfigExtension>();
 
     private boolean simulateFailures = false;
     private boolean simulateLinkingResources = false;
@@ -103,7 +103,6 @@ public class SimuComConfig extends AbstractSimulationConfig implements Serializa
     }
     
     private void doInit(final Map<String, Object> configuration, final boolean debug) {
-        simuComConfigExtensions = new HashMap<String, SimuComConfigExtension>();
         try {
             if (configuration.containsKey(SIMULATE_FAILURES)) {
                 this.simulateFailures = (Boolean) configuration.get(SIMULATE_FAILURES);

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/SimuComConfig.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/SimuComConfig.java
@@ -8,6 +8,7 @@ import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
 import org.palladiosimulator.analyzer.workflow.runconfig.ExperimentRunDescriptor;
+import org.palladiosimulator.recorderframework.config.IRecorderConfigurationFactory;
 
 import de.uka.ipd.sdq.probfunction.math.IRandomGenerator;
 import de.uka.ipd.sdq.simulation.AbstractSimulationConfig;
@@ -62,7 +63,7 @@ public class SimuComConfig extends AbstractSimulationConfig implements Serializa
 
     // SimuCom extensions can also provide extension to the SimuCom configuration.
     // This map stores the extension configurations.
-    private final HashMap<String, SimuComConfigExtension> simuComConfigExtensions;
+    private HashMap<String, SimuComConfigExtension> simuComConfigExtensions;
 
     private boolean simulateFailures = false;
     private boolean simulateLinkingResources = false;
@@ -91,8 +92,17 @@ public class SimuComConfig extends AbstractSimulationConfig implements Serializa
      *            SimuComConfig.CONFIDENCE_MODELELEMENT_URI
      *
      */
+    public SimuComConfig(final Map<String, Object> configuration, final boolean debug, IRecorderConfigurationFactory configurationFactory) {
+        super(configuration, debug, configurationFactory);
+        doInit(configuration, debug);
+    }
+    
     public SimuComConfig(final Map<String, Object> configuration, final boolean debug) {
         super(configuration, debug);
+        doInit(configuration, debug);
+    }
+    
+    private void doInit(final Map<String, Object> configuration, final boolean debug) {
         simuComConfigExtensions = new HashMap<String, SimuComConfigExtension>();
         try {
             if (configuration.containsKey(SIMULATE_FAILURES)) {

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/calculator/RecorderAttachingCalculatorFactoryDecorator.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/calculator/RecorderAttachingCalculatorFactoryDecorator.java
@@ -26,12 +26,6 @@ public class RecorderAttachingCalculatorFactoryDecorator implements IGenericCalc
     private final IGenericCalculatorFactory decoratedCalculatorFactory;
     private final String recorderName;
     private final IRecorderConfigurationFactory configurationFactory;
-
-    public RecorderAttachingCalculatorFactoryDecorator(final IGenericCalculatorFactory decoratedCalculatorFactory,
-            final String recorderName) {
-        this(decoratedCalculatorFactory, recorderName,
-                RecorderExtensionHelper.getRecorderConfigurationFactoryForName(recorderName));
-    }
     
     public RecorderAttachingCalculatorFactoryDecorator(final IGenericCalculatorFactory decoratedCalculatorFactory,
             final String recorderName, IRecorderConfigurationFactory configurationFactory) {

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/calculator/RecorderAttachingCalculatorFactoryDecorator.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/calculator/RecorderAttachingCalculatorFactoryDecorator.java
@@ -11,6 +11,7 @@ import org.palladiosimulator.probeframework.calculator.IGenericCalculatorFactory
 import org.palladiosimulator.recorderframework.IRecorder;
 import org.palladiosimulator.recorderframework.config.AbstractRecorderConfiguration;
 import org.palladiosimulator.recorderframework.config.IRecorderConfiguration;
+import org.palladiosimulator.recorderframework.config.IRecorderConfigurationFactory;
 import org.palladiosimulator.recorderframework.utils.RecorderExtensionHelper;
 
 /**
@@ -24,13 +25,19 @@ public class RecorderAttachingCalculatorFactoryDecorator implements IGenericCalc
      */
     private final IGenericCalculatorFactory decoratedCalculatorFactory;
     private final String recorderName;
+    private final IRecorderConfigurationFactory configurationFactory;
 
     public RecorderAttachingCalculatorFactoryDecorator(final IGenericCalculatorFactory decoratedCalculatorFactory,
             final String recorderName) {
-        super();
-
+        this(decoratedCalculatorFactory, recorderName,
+                RecorderExtensionHelper.getRecorderConfigurationFactoryForName(recorderName));
+    }
+    
+    public RecorderAttachingCalculatorFactoryDecorator(final IGenericCalculatorFactory decoratedCalculatorFactory,
+            final String recorderName, IRecorderConfigurationFactory configurationFactory) {
         this.decoratedCalculatorFactory = decoratedCalculatorFactory;
         this.recorderName = recorderName;
+        this.configurationFactory = configurationFactory;        
     }
 
     @Override
@@ -46,8 +53,7 @@ public class RecorderAttachingCalculatorFactoryDecorator implements IGenericCalc
         recorderConfigurationMap.put(AbstractRecorderConfiguration.MEASURING_POINT, calculator.getMeasuringPoint());
 
         final IRecorder recorder = RecorderExtensionHelper.instantiateRecorderImplementationForRecorder(recorderName);
-        final IRecorderConfiguration recorderConfiguration = RecorderExtensionHelper
-            .getRecorderConfigurationFactoryForName(recorderName)
+        final IRecorderConfiguration recorderConfiguration = configurationFactory
             .createRecorderConfiguration(recorderConfigurationMap);
         recorder.initialize(recorderConfiguration);
         // register recorder at calculator

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/calculator/RecorderAttachingCalculatorFactoryDecorator.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/calculator/RecorderAttachingCalculatorFactoryDecorator.java
@@ -6,14 +6,12 @@ import java.util.Map;
 import org.palladiosimulator.edp2.models.measuringpoint.MeasuringPoint;
 import org.palladiosimulator.metricspec.MetricDescription;
 import org.palladiosimulator.probeframework.calculator.Calculator;
-import org.palladiosimulator.probeframework.calculator.IGenericCalculatorFactory;
 import org.palladiosimulator.probeframework.calculator.CalculatorProbeSet;
+import org.palladiosimulator.probeframework.calculator.IGenericCalculatorFactory;
 import org.palladiosimulator.recorderframework.IRecorder;
 import org.palladiosimulator.recorderframework.config.AbstractRecorderConfiguration;
 import org.palladiosimulator.recorderframework.config.IRecorderConfiguration;
 import org.palladiosimulator.recorderframework.utils.RecorderExtensionHelper;
-
-import de.uka.ipd.sdq.simucomframework.SimuComConfig;
 
 /**
  * Factory class to create @see {@link Calculator}s used in a SimuCom simulation run.
@@ -24,16 +22,15 @@ public class RecorderAttachingCalculatorFactoryDecorator implements IGenericCalc
     /**
      * SimuCom model which is simulated
      */
-    private final SimuComConfig configuration;
-
     private final IGenericCalculatorFactory decoratedCalculatorFactory;
+    private final String recorderName;
 
     public RecorderAttachingCalculatorFactoryDecorator(final IGenericCalculatorFactory decoratedCalculatorFactory,
-            final SimuComConfig configuration) {
+            final String recorderName) {
         super();
 
         this.decoratedCalculatorFactory = decoratedCalculatorFactory;
-        this.configuration = configuration;
+        this.recorderName = recorderName;
     }
 
     @Override
@@ -48,10 +45,10 @@ public class RecorderAttachingCalculatorFactoryDecorator implements IGenericCalc
                 calculator.getMetricDesciption());
         recorderConfigurationMap.put(AbstractRecorderConfiguration.MEASURING_POINT, calculator.getMeasuringPoint());
 
-        final IRecorder recorder = RecorderExtensionHelper
-                .instantiateRecorderImplementationForRecorder(this.configuration.getRecorderName());
-        final IRecorderConfiguration recorderConfiguration = this.configuration.getRecorderConfigurationFactory()
-                .createRecorderConfiguration(recorderConfigurationMap);
+        final IRecorder recorder = RecorderExtensionHelper.instantiateRecorderImplementationForRecorder(recorderName);
+        final IRecorderConfiguration recorderConfiguration = RecorderExtensionHelper
+            .getRecorderConfigurationFactoryForName(recorderName)
+            .createRecorderConfiguration(recorderConfigurationMap);
         recorder.initialize(recorderConfiguration);
         // register recorder at calculator
         calculator.addObserver(recorder);

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/model/SimuComModel.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/model/SimuComModel.java
@@ -109,7 +109,7 @@ public class SimuComModel extends SchedulerModel {
     private ProbeFrameworkContext initialiseProbeFramework() {
         // create ProbeFramework context
         final ProbeFrameworkContext result = new ProbeFrameworkContext(new RecorderAttachingCalculatorFactoryDecorator(
-                new ExtensibleCalculatorFactoryDelegatingFactory(), this.config.getRecorderName()));
+                new ExtensibleCalculatorFactoryDelegatingFactory(), this.config.getRecorderName(), this.config.getRecorderConfigurationFactory()));
 
         return result;
     }

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/model/SimuComModel.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/model/SimuComModel.java
@@ -63,16 +63,29 @@ public class SimuComModel extends SchedulerModel {
     private final ISchedulingFactory schedulingFactory;
     private final FailureStatistics failureStatistics = new FailureStatistics();
 
+    /**
+     * Creates a new SimuComModel. ProbeFrameworkContext and ResourceRegistry are created as part of this constructor.
+     * 
+     * Legacy behavior of SimuCom. 
+     */
+    @Deprecated
     public SimuComModel(final SimuComConfig config, final SimuComStatus status, final ISimEngineFactory factory,
             final boolean isRemoteRun, IResourceTableManager resourceTableManager) {
         this(config, status, factory, isRemoteRun, null, resourceTableManager);
     }
-    
+
+    /**
+     * Creates a new SimuComModel. The ResourceRegistry is created as part of this constructor.
+     */
+    @Deprecated
     public SimuComModel(final SimuComConfig config, final SimuComStatus status, final ISimEngineFactory factory,
             final boolean isRemoteRun, final ProbeFrameworkContext probeFrameworkContext, IResourceTableManager resourceTableManager) {
         this(config, status, factory, isRemoteRun, probeFrameworkContext, resourceTableManager, null);
     }
 
+    /**
+     * Creates a new SimuComModel. Please use this constructor for future work.
+     */
     public SimuComModel(final SimuComConfig config, final SimuComStatus status, final ISimEngineFactory factory,
             final boolean isRemoteRun, final ProbeFrameworkContext probeFrameworkContext, IResourceTableManager resourceTableManager,
             ResourceRegistry resourceRegistry) {
@@ -80,6 +93,7 @@ public class SimuComModel extends SchedulerModel {
         this.simulationEngineFactory = factory;
         factory.setModel(this);
         this.simControl = factory.createSimulationControl();
+        // Initializing the ResourceRegistry in case it was not provided (legacy behavior of SimuCom)
         this.resourceRegistry = resourceRegistry == null ? new ResourceRegistry(this) : resourceRegistry;
         this.simulationStatus = status;
         issues = new ArrayList<SeverityAndIssue>();
@@ -99,7 +113,7 @@ public class SimuComModel extends SchedulerModel {
         // set up the resource scheduler
         schedulingFactory = new SchedulingFactory(this, resourceTableManager);
 
-        // set up the measurement framework
+        // Initializing the ProbeFrameworkContext in case it was not provided (legacy behavior of SimuCom)
         this.probeFrameworkContext = probeFrameworkContext == null ? initialiseProbeFramework() : probeFrameworkContext;
 
         // setup debug log for console

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/model/SimuComModel.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/model/SimuComModel.java
@@ -3,7 +3,6 @@ package de.uka.ipd.sdq.simucomframework.model;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.log4j.Level;
@@ -11,7 +10,6 @@ import org.apache.log4j.Logger;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.ecore.util.EContentAdapter;
 import org.palladiosimulator.probeframework.ProbeFrameworkContext;
-import org.palladiosimulator.probeframework.calculator.DefaultCalculatorFactory;
 import org.palladiosimulator.probeframework.calculator.ExtensibleCalculatorFactoryDelegatingFactory;
 import org.palladiosimulator.reliability.FailureStatistics;
 
@@ -21,7 +19,6 @@ import de.uka.ipd.sdq.probfunction.math.impl.ProbabilityFunctionFactoryImpl;
 import de.uka.ipd.sdq.scheduler.ISchedulingFactory;
 import de.uka.ipd.sdq.scheduler.SchedulerModel;
 import de.uka.ipd.sdq.scheduler.factory.SchedulingFactory;
-import de.uka.ipd.sdq.scheduler.resources.active.AbstractActiveResource;
 import de.uka.ipd.sdq.scheduler.resources.active.IResourceTableManager;
 import de.uka.ipd.sdq.simucomframework.ResourceRegistry;
 import de.uka.ipd.sdq.simucomframework.SimuComConfig;
@@ -70,14 +67,20 @@ public class SimuComModel extends SchedulerModel {
             final boolean isRemoteRun, IResourceTableManager resourceTableManager) {
         this(config, status, factory, isRemoteRun, null, resourceTableManager);
     }
-
+    
     public SimuComModel(final SimuComConfig config, final SimuComStatus status, final ISimEngineFactory factory,
             final boolean isRemoteRun, final ProbeFrameworkContext probeFrameworkContext, IResourceTableManager resourceTableManager) {
+        this(config, status, factory, isRemoteRun, probeFrameworkContext, resourceTableManager, null);
+    }
+
+    public SimuComModel(final SimuComConfig config, final SimuComStatus status, final ISimEngineFactory factory,
+            final boolean isRemoteRun, final ProbeFrameworkContext probeFrameworkContext, IResourceTableManager resourceTableManager,
+            ResourceRegistry resourceRegistry) {
         this.config = config;
         this.simulationEngineFactory = factory;
         factory.setModel(this);
         this.simControl = factory.createSimulationControl();
-        resourceRegistry = new ResourceRegistry(this);
+        this.resourceRegistry = resourceRegistry == null ? new ResourceRegistry(this) : resourceRegistry;
         this.simulationStatus = status;
         issues = new ArrayList<SeverityAndIssue>();
         this.workloadDrivers = new ArrayList<IWorkloadDriver>();
@@ -106,7 +109,7 @@ public class SimuComModel extends SchedulerModel {
     private ProbeFrameworkContext initialiseProbeFramework() {
         // create ProbeFramework context
         final ProbeFrameworkContext result = new ProbeFrameworkContext(new RecorderAttachingCalculatorFactoryDecorator(
-                new ExtensibleCalculatorFactoryDelegatingFactory(), this.config));
+                new ExtensibleCalculatorFactoryDelegatingFactory(), this.config.getRecorderName()));
 
         return result;
     }

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/probes/TakeCurrentSimulationTimeProbe.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/probes/TakeCurrentSimulationTimeProbe.java
@@ -9,7 +9,7 @@ import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
 import org.palladiosimulator.probeframework.measurement.RequestContext;
 import org.palladiosimulator.probeframework.probes.BasicObjectStateProbe;
 
-import de.uka.ipd.sdq.simulation.abstractsimengine.ISimulationControl;
+import de.uka.ipd.sdq.simulation.abstractsimengine.ISimulationTimeProvider;
 
 /**
  * Measures a point in time metric (in seconds) by requesting the current simulation time from the
@@ -17,7 +17,7 @@ import de.uka.ipd.sdq.simulation.abstractsimengine.ISimulationControl;
  *
  * @author Sebastian Lehrig, Steffen Becker
  */
-public class TakeCurrentSimulationTimeProbe extends BasicObjectStateProbe<ISimulationControl, Double, Duration> {
+public class TakeCurrentSimulationTimeProbe extends BasicObjectStateProbe<ISimulationTimeProvider, Double, Duration> {
 
     /**
      * Default constructor.
@@ -26,8 +26,8 @@ public class TakeCurrentSimulationTimeProbe extends BasicObjectStateProbe<ISimul
      *            The observer object is a simulation control, thus, allowing to request the current
      *            simulation time.
      */
-    public TakeCurrentSimulationTimeProbe(final ISimulationControl simulationControl) {
-        super(simulationControl, MetricDescriptionConstants.POINT_IN_TIME_METRIC);
+    public TakeCurrentSimulationTimeProbe(final ISimulationTimeProvider timeProvider) {
+        super(timeProvider, MetricDescriptionConstants.POINT_IN_TIME_METRIC);
     }
 
     /**

--- a/bundles/de.uka.ipd.sdq.simulation/src/de/uka/ipd/sdq/simulation/AbstractSimulationConfig.java
+++ b/bundles/de.uka.ipd.sdq.simulation/src/de/uka/ipd/sdq/simulation/AbstractSimulationConfig.java
@@ -73,13 +73,27 @@ public abstract class AbstractSimulationConfig implements Serializable, ISimulat
     private final String simulatorId;
 
     /**
+     * Constructs a new AbstractSimulationConfig.
+     * 
+     * This constructor initializes the RecorderFramework (legacy).
      * @param configuration
-     *            a map which maps configuration option IDs to their values. The required keys are
-     *            <ul>
-     *            <li>SimuComConfig.VERBOSE_LOGGING
-     *            </ul>
+     *            a map which maps configuration option IDs to their values.
      */
     public AbstractSimulationConfig(final Map<String, Object> configuration, final boolean debug) {
+        this(configuration, debug, null);
+        this.recorderConfigurationFactory = RecorderExtensionHelper.getRecorderConfigurationFactoryForName(this.recorderName);
+        this.recorderConfigurationFactory.initialize(configuration);
+    }
+    
+    /**
+     * Constructs a new AbstractSimulationConfig.
+     * 
+     * This constructor allows to circumvent the inflexible instantiation and initialization of
+     * IRecorderConfigurationFactory as part of the constructor.
+     * 
+     * This constructor does not initialize the RecorderFramework.
+     */
+    public AbstractSimulationConfig(final Map<String, Object> configuration, final boolean debug, IRecorderConfigurationFactory configFactory) {
         this.verboseLogging = (Boolean) configuration.get(VERBOSE_LOGGING);
         this.isDebug = debug;
         this.variationId = (String) configuration.get(VARIATION_ID);
@@ -91,11 +105,10 @@ public abstract class AbstractSimulationConfig implements Serializable, ISimulat
         this.randomSeed = getSeedFromConfig(configuration);
 
         this.recorderName = (String) configuration.get(PERSISTENCE_RECORDER_NAME);
-        this.recorderConfigurationFactory = RecorderExtensionHelper
-                .getRecorderConfigurationFactoryForName(this.recorderName);
-        this.recorderConfigurationFactory.initialize(configuration);
+        
+        this.recorderConfigurationFactory = configFactory;
 
-        this.listeners = new ArrayList<ISimulationListener>();
+        this.listeners = new ArrayList<ISimulationListener>();        
     }
 
     /**
@@ -104,6 +117,8 @@ public abstract class AbstractSimulationConfig implements Serializable, ISimulat
     public final IRecorderConfigurationFactory getRecorderConfigurationFactory() {
         return this.recorderConfigurationFactory;
     }
+    
+    
 
     public boolean getVerboseLogging() {
         return this.verboseLogging || this.isDebug;


### PR DESCRIPTION
* Use Recordername parameter directly instead of SimuComConfig
* Allow to instantiate ResourceRegistry externally (Make SimuComModel more lightweight)