### PR TITLE
Relax version constraint to org.eclipse.core.debug

### DIFF
--- a/bundles/org.palladiosimulator.simucom.launch/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.simucom.launch/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-Version: 4.3.0.qualifier
 Automatic-Module-Name: org.palladiosimulator.simucom.launch
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: de.uka.ipd.sdq.codegen.simucontroller;bundle-version="4.3.0",
- org.eclipse.debug.core;bundle-version="3.17.0",
+ org.eclipse.debug.core,
  de.uka.ipd.sdq.simucom.rerunsimulation;bundle-version="4.3.0"


### PR DESCRIPTION
Version constraint to 2020-12 is not required, as no dedicated 2020-12 functionality is used.