### PR TITLE
Changed SimuCom Template by using SimuComContext instead of Context

### DIFF
--- a/bundles/de.uka.ipd.sdq.pcm.codegen.simucom/src-transforms/de/uka/ipd/sdq/pcm/codegen/simucom/transformations/sim/SimJavaCoreXpt.xtend
+++ b/bundles/de.uka.ipd.sdq.pcm.codegen.simucom/src-transforms/de/uka/ipd/sdq/pcm/codegen/simucom/transformations/sim/SimJavaCoreXpt.xtend
@@ -259,7 +259,7 @@ class SimJavaCoreXpt extends JavaCoreXpt {
 	override parameterListTM(Signature signature)      '''de.uka.ipd.sdq.simucomframework.SimuComContext ctx'''
 	override parameterUsageListTM(Signature signature) '''ctx'''
 	override returnTypeTM(Signature signature)         '''de.uka.ipd.sdq.simucomframework.variables.stackframe.SimulatedStackframe<Object>'''
-	override contextTypeTM(AbstractAction action)      '''de.uka.ipd.sdq.simucomframework.Context'''
+	override contextTypeTM(AbstractAction action)      '''de.uka.ipd.sdq.simucomframework.SimuComContext'''
 	
 	override componentServiceTM(Signature signature, RepositoryComponent component) {
 		componentService(signature, component)

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/fork/ForkContext.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/fork/ForkContext.java
@@ -1,6 +1,7 @@
 package de.uka.ipd.sdq.simucomframework.fork;
 
 import de.uka.ipd.sdq.simucomframework.Context;
+import de.uka.ipd.sdq.simucomframework.SimuComContext;
 import de.uka.ipd.sdq.simucomframework.SimuComSimProcess;
 import de.uka.ipd.sdq.simucomframework.resources.AbstractSimulatedResourceContainer;
 import de.uka.ipd.sdq.simucomframework.resources.IAssemblyAllocationLookup;
@@ -12,7 +13,7 @@ import de.uka.ipd.sdq.simucomframework.variables.stackframe.SimulatedStack;
  * @author Steffen Becker
  *
  */
-public class ForkContext extends Context {
+public class ForkContext extends SimuComContext {
 
     private static final long serialVersionUID = 6701742993106975705L;
 
@@ -44,5 +45,10 @@ public class ForkContext extends Context {
     @Override
     public IAssemblyAllocationLookup<AbstractSimulatedResourceContainer> getAssemblyAllocationLookup() {
         return getParentContext().getAssemblyAllocationLookup();
+    }
+
+    @Override
+    protected void initialiseAssemblyContextLookup() {
+        // not required; as assemblyContextLookup is delegated to parent context
     }
 }

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/fork/ForkedBehaviourProcess.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/fork/ForkedBehaviourProcess.java
@@ -4,6 +4,7 @@ import org.apache.log4j.Logger;
 
 import de.uka.ipd.sdq.scheduler.resources.active.IResourceTableManager;
 import de.uka.ipd.sdq.simucomframework.Context;
+import de.uka.ipd.sdq.simucomframework.SimuComContext;
 import de.uka.ipd.sdq.simucomframework.SimuComSimProcess;
 import de.uka.ipd.sdq.simulation.abstractsimengine.ISimProcess;
 
@@ -18,7 +19,7 @@ public abstract class ForkedBehaviourProcess extends SimuComSimProcess {
 
     private static final Logger LOGGER = Logger.getLogger(ForkedBehaviourProcess.class.getName());
 
-    protected final Context forkContext;
+    protected final SimuComContext forkContext;
     protected final String assemblyContextID;
     
     private final ISimProcess parentProcess;
@@ -45,7 +46,7 @@ public abstract class ForkedBehaviourProcess extends SimuComSimProcess {
      * @param context
      * @return
      */
-    protected Context createForkContext(Context context) {
+    protected SimuComContext createForkContext(Context context) {
         return new ForkContext(context, this);
     }
 


### PR DESCRIPTION
changed template by changing contextType from *.Context to *.SimuComC…ontext; ForkContext now inherits from SimuComContext instead of Context