### PR TITLE
[SIMULIZAR-147] Fix check for root-level component

### DIFF
--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/IAssemblyAllocationLookup.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/IAssemblyAllocationLookup.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 
 import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.pcm.repository.BasicComponent;
+import org.palladiosimulator.pcm.repository.RepositoryComponent;
 
 import de.uka.ipd.sdq.identifier.Identifier;
 
@@ -39,7 +40,7 @@ public interface IAssemblyAllocationLookup<AllocationType> {
      * @return the entity
      */
     default AllocationType getAllocatedEntity(AssemblyContext context) {
-        if (context.getParentStructure__AssemblyContext() instanceof BasicComponent) {
+        if (context.getParentStructure__AssemblyContext() instanceof RepositoryComponent) {
             throw new IllegalArgumentException("Only root assembly contexts can be allocated directly. "
                     + "Please use getAllocatedEntity(Stack<AssemblyContext>).");
         }


### PR DESCRIPTION
This fix does not prevent SIMULIZAR-147 (which needs to be fixed in SimuLizar), but leads to a more appropriate error message. An assembly context is not sufficient to determine which resource container it is allocated to, when the assembly context is part of a composite component. 