### PR TITLE
PALLADIO-503 Remove old StoEx Parser/Serialise/Utilities

### DIFF
--- a/bundles/de.uka.ipd.sdq.simucomframework.variables/src/de/uka/ipd/sdq/simucomframework/variables/cache/StoExCacheEntry.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework.variables/src/de/uka/ipd/sdq/simucomframework/variables/cache/StoExCacheEntry.java
@@ -1,10 +1,10 @@
 package de.uka.ipd.sdq.simucomframework.variables.cache;
 
+import java.text.ParseException;
 import java.util.Iterator;
 
 import org.eclipse.emf.ecore.EObject;
 import org.palladiosimulator.pcm.stoex.api.StoExParser;
-import org.palladiosimulator.pcm.stoex.api.StoExParser.SyntaxErrorException;
 
 import de.uka.ipd.sdq.probfunction.math.IProbabilityFunction;
 import de.uka.ipd.sdq.stoex.Expression;
@@ -41,7 +41,7 @@ public class StoExCacheEntry {
         Expression formula = null;
         try {
             formula = STOEX_PARSER.parse(spec);
-        } catch (SyntaxErrorException e) {
+        } catch (ParseException e) {
             throw new RuntimeException("Expression not parsable \"" + spec + "\"", e);
         }
         try {

--- a/bundles/de.uka.ipd.sdq.simucomframework.variables/src/de/uka/ipd/sdq/simucomframework/variables/stoexvisitor/PCMStoExEvaluationVisitor.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework.variables/src/de/uka/ipd/sdq/simucomframework/variables/stoexvisitor/PCMStoExEvaluationVisitor.java
@@ -1,12 +1,12 @@
 package de.uka.ipd.sdq.simucomframework.variables.stoexvisitor;
 
+import java.io.NotSerializableException;
 import java.util.ArrayList;
 import java.util.Map.Entry;
 
 import org.apache.log4j.Logger;
 import org.palladiosimulator.pcm.parameter.CharacterisedVariable;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 
 import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExSwitch;
 import de.uka.ipd.sdq.probfunction.math.IProbabilityFunctionFactory;
@@ -102,7 +102,7 @@ public class PCMStoExEvaluationVisitor extends PCMStoExSwitch {
         String variableID;
         try {
             variableID = STOEX_SERIALISER.serialise(object);
-        } catch (SerialisationErrorException e1) {
+        } catch (NotSerializableException e1) {
             LOGGER.error("Could not serialise variable.", e1);
             throw new RuntimeException("Given variable is not serialisable.", e1);
         }

--- a/bundles/de.uka.ipd.sdq.simucomframework.variables/src/de/uka/ipd/sdq/simucomframework/variables/stoexvisitor/PCMStoExEvaluationVisitor.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework.variables/src/de/uka/ipd/sdq/simucomframework/variables/stoexvisitor/PCMStoExEvaluationVisitor.java
@@ -4,9 +4,10 @@ import java.util.ArrayList;
 import java.util.Map.Entry;
 
 import org.apache.log4j.Logger;
-
 import org.palladiosimulator.pcm.parameter.CharacterisedVariable;
-import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExPrettyPrintVisitor;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
+
 import de.uka.ipd.sdq.pcm.stochasticexpressions.PCMStoExSwitch;
 import de.uka.ipd.sdq.probfunction.math.IProbabilityFunctionFactory;
 import de.uka.ipd.sdq.simucomframework.variables.EvaluationProxy;
@@ -46,6 +47,8 @@ import de.uka.ipd.sdq.stoex.analyser.visitors.TypeEnum;
  */
 public class PCMStoExEvaluationVisitor extends PCMStoExSwitch {
 
+    protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+    
     /**
      * This class' LOGGER
      */
@@ -96,7 +99,13 @@ public class PCMStoExEvaluationVisitor extends PCMStoExSwitch {
 
     @Override
     public Object caseCharacterisedVariable(CharacterisedVariable object) {
-        String variableID = new PCMStoExPrettyPrintVisitor().prettyPrint(object);
+        String variableID;
+        try {
+            variableID = STOEX_SERIALISER.serialise(object);
+        } catch (SerialisationErrorException e1) {
+            LOGGER.error("Could not serialise variable.", e1);
+            throw new RuntimeException("Given variable is not serialisable.", e1);
+        }
         try {
             Object value = this.myStackFrame.getValue(variableID);
             if (value instanceof EvaluationProxy) {


### PR DESCRIPTION
As requested by [PALLADIO-503](https://palladio-simulator.atlassian.net/browse/PALLADIO-503), I removed the hand-written StoEx parsers, serialisers and utilities and adjusted the code that used these classes.

This PR requires PalladioSimulator/Palladio-Core-PCM#31 to be merged before it compiles.