### PR TITLE
added missing method for parent resource container fallback

### DIFF
--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/SimulatedResourceContainer.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/SimulatedResourceContainer.java
@@ -140,6 +140,41 @@ public class SimulatedResourceContainer extends AbstractSimulatedResourceContain
             final AssemblyContext assemblyContext, final SimuComModel simuComModel, final long capacity) {
         return new SimSimpleFairPassiveResource(resource, assemblyContext, simuComModel, capacity);
     }
+    
+    /**
+     * Demand processing of a resource demand by a given type of active
+     * resources In future versions this has to control schedulers of resource
+     * types which exist in multiple instances, use parent container when resource not found
+     *
+     * @param requestingProcess
+     *            The thread requesting the processing of a resource demand
+     * @param resourceServiceID
+     *            the id of the resource service to be called.
+     * @param typeID
+     *            ID of the resource type to which the demand is directed. Same
+     *            as the PCM resource type IDs
+     * @param demand
+     *            The demand in units processable by the resource. The resource
+     *            is responsible itself for converting this demand into time
+     *            spans
+     */
+    public void loadActiveResource(final SimuComSimProcess requestingProcess, final int resourceServiceID,
+            final String typeID, final double demand) {
+    	  try {
+              super.loadActiveResource(requestingProcess, resourceServiceID, typeID, demand);
+          } catch (final ResourceContainerIsMissingRequiredResourceType e) {
+              if (this.parentResourceContainer == null) {
+                  if (LOGGER.isEnabledFor(Level.ERROR)) {
+                      LOGGER.error("Resource container is missing a resource which was attempted to be loaded"
+                              + " by a component and has no parent Resource Container to look in. ID of resource type was: "
+                              + typeID);
+                  }
+                  throw new ResourceContainerIsMissingRequiredResourceType(typeID);
+              } else {
+                  this.parentResourceContainer.loadActiveResource(requestingProcess, resourceServiceID, typeID, demand);
+              }
+          }
+    }
 
     /**
      * Demand processing of a resource demand by a given type of active resources. If the resource

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/SimulatedResourceContainer.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/SimulatedResourceContainer.java
@@ -170,7 +170,7 @@ public class SimulatedResourceContainer extends AbstractSimulatedResourceContain
                               + " by a component and has no parent Resource Container to look in. ID of resource type was: "
                               + typeID);
                   }
-                  throw new ResourceContainerIsMissingRequiredResourceType(typeID);
+                  throw e;
               } else {
                   this.parentResourceContainer.loadActiveResource(requestingProcess, resourceServiceID, typeID, demand);
               }
@@ -201,7 +201,7 @@ public class SimulatedResourceContainer extends AbstractSimulatedResourceContain
                             + " by a component and has no parent Resource Container to look in. ID of resource type was: "
                             + typeID);
                 }
-                throw new ResourceContainerIsMissingRequiredResourceType(typeID);
+                throw e;
             } else {
                 this.parentResourceContainer.loadActiveResource(requestingProcess, typeID, demand);
             }
@@ -235,7 +235,7 @@ public class SimulatedResourceContainer extends AbstractSimulatedResourceContain
                             + " by a component and has no parent Resource Container to look in. ID of resource type was: "
                             + e.getTypeID());
                 }
-                throw new ResourceContainerIsMissingRequiredResourceType(e.getTypeID());
+                throw e;
             } else {
                 this.parentResourceContainer.loadActiveResource(requestingProcess, providedInterfaceID, resourceServiceID,
                         demand);
@@ -273,7 +273,7 @@ public class SimulatedResourceContainer extends AbstractSimulatedResourceContain
                             + " by a component and has no parent Resource Container to look in. ID of resource type was: "
                             + e.getTypeID());
                 }
-                throw new ResourceContainerIsMissingRequiredResourceType(e.getTypeID());
+                throw e;
             } else {
                 this.parentResourceContainer.loadActiveResource(requestingProcess, providedInterfaceID, resourceServiceID,
                         parameterMap, demand);

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/SimulatedResourceContainer.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/SimulatedResourceContainer.java
@@ -143,8 +143,8 @@ public class SimulatedResourceContainer extends AbstractSimulatedResourceContain
     
     /**
      * Demand processing of a resource demand by a given type of active
-     * resources In future versions this has to control schedulers of resource
-     * types which exist in multiple instances, use parent container when resource not found
+     * resources. In future versions this has to control schedulers of resource
+     * types which exist in multiple instances, use parent container when resource not found.
      *
      * @param requestingProcess
      *            The thread requesting the processing of a resource demand
@@ -158,6 +158,7 @@ public class SimulatedResourceContainer extends AbstractSimulatedResourceContain
      *            is responsible itself for converting this demand into time
      *            spans
      */
+    @Override
     public void loadActiveResource(final SimuComSimProcess requestingProcess, final int resourceServiceID,
             final String typeID, final double demand) {
     	  try {
@@ -244,7 +245,7 @@ public class SimulatedResourceContainer extends AbstractSimulatedResourceContain
 
     /**
      * Demand processing of a resource demand by a given type of active resource and a resource
-     * interface operation and additional parameters which can be used in an active resource
+     * interface operation and additional parameters which can be used in an active resource.
      *
      * @param requestingProcess
      *            The thread requesting the processing of a resource demand

--- a/releng/org.palladiosimulator.simucom.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.simucom.targetplatform/tp.target
@@ -173,6 +173,12 @@
 			<unit id="org.palladiosimulator.scheduler.feature.feature.group" version="0.0.0"/>
 			<repository location="https://updatesite.palladio-simulator.com/palladio-simulation-scheduler/nightly/"/>
 		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2021-12/"/>
+			<unit id="org.mockito" version="0.0.0"/>
+			<unit id="net.bytebuddy.byte-buddy" version="0.0.0"/>
+			<unit id="org.objenesis" version="0.0.0"/>
+		</location>
 		
 	</locations>
 </target>

--- a/tests/de.uka.ipd.sdq.simucomframework.tests/.classpath
+++ b/tests/de.uka.ipd.sdq.simucomframework.tests/.classpath
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/tests/de.uka.ipd.sdq.simucomframework.tests/.project
+++ b/tests/de.uka.ipd.sdq.simucomframework.tests/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>de.uka.ipd.sdq.simucomframework.tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/tests/de.uka.ipd.sdq.simucomframework.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/tests/de.uka.ipd.sdq.simucomframework.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11

--- a/tests/de.uka.ipd.sdq.simucomframework.tests/META-INF/MANIFEST.MF
+++ b/tests/de.uka.ipd.sdq.simucomframework.tests/META-INF/MANIFEST.MF
@@ -1,0 +1,13 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Simucom Framework Tests
+Bundle-SymbolicName: de.uka.ipd.sdq.simucomframework.tests
+Bundle-Version: 1.0.0.qualifier
+Fragment-Host: de.uka.ipd.sdq.simucomframework;bundle-version="5.0.0"
+Automatic-Module-Name: de.uka.ipd.sdq.simucomframework.tests
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Require-Bundle: org.junit,
+ org.junit.jupiter.api,
+ org.mockito;bundle-version="2.23.0",
+ net.bytebuddy.byte-buddy;bundle-version="1.9.0",
+ org.objenesis;bundle-version="2.6.0"

--- a/tests/de.uka.ipd.sdq.simucomframework.tests/build.properties
+++ b/tests/de.uka.ipd.sdq.simucomframework.tests/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/tests/de.uka.ipd.sdq.simucomframework.tests/src/de/uka/ipd/sdq/simucomframework/tests/SimulatedResourceContainerTests.java
+++ b/tests/de.uka.ipd.sdq.simucomframework.tests/src/de/uka/ipd/sdq/simucomframework/tests/SimulatedResourceContainerTests.java
@@ -1,0 +1,87 @@
+package de.uka.ipd.sdq.simucomframework.tests;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import de.uka.ipd.sdq.simucomframework.ResourceRegistry;
+import de.uka.ipd.sdq.simucomframework.SimuComSimProcess;
+import de.uka.ipd.sdq.simucomframework.model.SimuComModel;
+import de.uka.ipd.sdq.simucomframework.resources.SimulatedResourceContainer;
+
+class SimulatedResourceContainerTests {
+
+	@Test
+	void testBasicNestedResourceContainer() {
+		
+		var mockModel = Mockito.mock(SimuComModel.class);
+		var resourceRegistry = new ResourceRegistry(mockModel);
+		Mockito.when(mockModel.getResourceRegistry()).thenReturn(resourceRegistry);
+		
+		//Given a container with a single child container
+		String parentContainerId = "container0";
+		SimulatedResourceContainer parentContainer = new SimulatedResourceContainer(mockModel, parentContainerId);
+		resourceRegistry.addResourceContainer(parentContainer);
+		
+		String childContainerId = "container1";
+		SimulatedResourceContainer childContainer = new SimulatedResourceContainer(mockModel, childContainerId);
+		resourceRegistry.addResourceContainer(childContainer);
+		childContainer.setParentResourceContainer(parentContainerId);
+		parentContainer.addNestedResourceContainer(childContainerId);
+		
+		
+		var nested = parentContainer.getNestedResourceContainers();
+		assertEquals(1, nested.size(), "we should have one nested container");
+		
+		var foundContainer = nested.get(0);
+		assertEquals(childContainerId, foundContainer.getResourceContainerID(), "nested container should have our Id");
+		assertEquals(parentContainer, foundContainer.getParentResourceContainer(), "child should have our parent as container");
+		
+	}
+	
+	
+	
+	@Test
+	void testNestedResourceContainerCalls() {
+		
+		var mockModel = Mockito.mock(SimuComModel.class);
+		var resourceRegistry = new ResourceRegistry(mockModel);
+		Mockito.when(mockModel.getResourceRegistry()).thenReturn(resourceRegistry);
+		
+		//Given a container with a single child container
+		String parentContainerId = "container0";
+		SimulatedResourceContainer parentContainer = Mockito.mock(SimulatedResourceContainer.class);
+		Mockito.when(parentContainer.getResourceContainerID()).thenReturn(parentContainerId);
+		resourceRegistry.addResourceContainer(parentContainer);
+		
+		
+		String childContainerId = "container1";
+		SimulatedResourceContainer childContainer = new SimulatedResourceContainer(mockModel, childContainerId);
+		resourceRegistry.addResourceContainer(childContainer);
+		childContainer.setParentResourceContainer(parentContainerId);
+		parentContainer.addNestedResourceContainer(childContainerId);
+		
+		// check fallback to parent
+		var simProcess = Mockito.mock(SimuComSimProcess.class);
+		parentContainer.loadActiveResource(simProcess, "dummy", 100);
+		Mockito.verify(parentContainer).loadActiveResource(simProcess, "dummy", 100);
+		
+		parentContainer.loadActiveResource(simProcess, "dummy", 0, 100);
+		Mockito.verify(parentContainer).loadActiveResource(simProcess, "dummy", 0, 100);
+		
+		parentContainer.loadActiveResource(simProcess, "dummy", 0, Collections.emptyMap(), 100);
+		Mockito.verify(parentContainer).loadActiveResource(simProcess, "dummy", 0, Collections.emptyMap(), 100);
+		
+		parentContainer.loadActiveResource(simProcess, 0, "dummy", 100);
+		Mockito.verify(parentContainer).loadActiveResource(simProcess, 0, "dummy", 100);
+		
+	}
+	
+	
+	
+	
+
+}

--- a/tests/de.uka.ipd.sdq.simucomframework.tests/src/de/uka/ipd/sdq/simucomframework/tests/SimulatedResourceContainerTests.java
+++ b/tests/de.uka.ipd.sdq.simucomframework.tests/src/de/uka/ipd/sdq/simucomframework/tests/SimulatedResourceContainerTests.java
@@ -1,87 +1,198 @@
 package de.uka.ipd.sdq.simucomframework.tests;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.palladiosimulator.pcm.core.CoreFactory;
+import org.palladiosimulator.pcm.core.PCMRandomVariable;
+import org.palladiosimulator.pcm.resourceenvironment.ProcessingResourceSpecification;
+import org.palladiosimulator.pcm.resourceenvironment.ResourceContainer;
+import org.palladiosimulator.pcm.resourcetype.ProcessingResourceType;
 
+import de.uka.ipd.sdq.scheduler.ISchedulingFactory;
+import de.uka.ipd.sdq.scheduler.resources.active.SimDelayResource;
 import de.uka.ipd.sdq.simucomframework.ResourceRegistry;
+import de.uka.ipd.sdq.simucomframework.SimuComConfig;
 import de.uka.ipd.sdq.simucomframework.SimuComSimProcess;
+import de.uka.ipd.sdq.simucomframework.exceptions.ResourceContainerIsMissingRequiredResourceType;
 import de.uka.ipd.sdq.simucomframework.model.SimuComModel;
+import de.uka.ipd.sdq.simucomframework.resources.SchedulingStrategy;
 import de.uka.ipd.sdq.simucomframework.resources.SimulatedResourceContainer;
+import de.uka.ipd.sdq.simucomframework.simucomstatus.SimucomstatusFactory;
+import de.uka.ipd.sdq.simulation.abstractsimengine.IEntity;
+import de.uka.ipd.sdq.simulation.abstractsimengine.ISimEngineFactory;
 
 class SimulatedResourceContainerTests {
 
+	// Mocks
+	SimuComModel mockModel;
+	ResourceRegistry resourceRegistry;
+	ISimEngineFactory simEngineFactory;
+	ISchedulingFactory schedulingFactory;
+	SimuComConfig simuComConfig;
+
+	@BeforeEach
+	void createMockModel() {
+
+		mockModel = mock(SimuComModel.class);
+
+		simEngineFactory = mock(ISimEngineFactory.class);
+		when(mockModel.getSimEngineFactory()).thenReturn(simEngineFactory);
+
+		resourceRegistry = new ResourceRegistry(mockModel);
+		when(mockModel.getResourceRegistry()).thenReturn(resourceRegistry);
+		
+		var status = SimucomstatusFactory.eINSTANCE.createSimuComStatus();
+		status.setResourceStatus(SimucomstatusFactory.eINSTANCE.createSimulatedResources());
+		when(mockModel.getSimulationStatus()).thenReturn(status);
+		
+		schedulingFactory = mock(ISchedulingFactory.class);
+		when(mockModel.getSchedulingFactory()).thenReturn(schedulingFactory);
+		
+		simuComConfig = mock(SimuComConfig.class);
+		when(simuComConfig.getSimulateFailures()).thenReturn(false);
+		when(mockModel.getConfiguration()).thenReturn(simuComConfig);
+		
+	}
+
 	@Test
 	void testBasicNestedResourceContainer() {
-		
-		var mockModel = Mockito.mock(SimuComModel.class);
-		var resourceRegistry = new ResourceRegistry(mockModel);
-		Mockito.when(mockModel.getResourceRegistry()).thenReturn(resourceRegistry);
-		
-		//Given a container with a single child container
+
+		// Given a container with a single child container
 		String parentContainerId = "container0";
 		SimulatedResourceContainer parentContainer = new SimulatedResourceContainer(mockModel, parentContainerId);
 		resourceRegistry.addResourceContainer(parentContainer);
-		
+
 		String childContainerId = "container1";
 		SimulatedResourceContainer childContainer = new SimulatedResourceContainer(mockModel, childContainerId);
 		resourceRegistry.addResourceContainer(childContainer);
 		childContainer.setParentResourceContainer(parentContainerId);
 		parentContainer.addNestedResourceContainer(childContainerId);
-		
-		
+
 		var nested = parentContainer.getNestedResourceContainers();
 		assertEquals(1, nested.size(), "we should have one nested container");
-		
+
 		var foundContainer = nested.get(0);
 		assertEquals(childContainerId, foundContainer.getResourceContainerID(), "nested container should have our Id");
-		assertEquals(parentContainer, foundContainer.getParentResourceContainer(), "child should have our parent as container");
-		
+		assertEquals(parentContainer, foundContainer.getParentResourceContainer(),
+				"child should have our parent as container");
+
 	}
-	
-	
-	
+
 	@Test
 	void testNestedResourceContainerCalls() {
-		
-		var mockModel = Mockito.mock(SimuComModel.class);
-		var resourceRegistry = new ResourceRegistry(mockModel);
-		Mockito.when(mockModel.getResourceRegistry()).thenReturn(resourceRegistry);
-		
-		//Given a container with a single child container
+
+		// Given a container with a single child container
 		String parentContainerId = "container0";
-		SimulatedResourceContainer parentContainer = Mockito.mock(SimulatedResourceContainer.class);
-		Mockito.when(parentContainer.getResourceContainerID()).thenReturn(parentContainerId);
+		SimulatedResourceContainer parentContainer = mock(SimulatedResourceContainer.class);
+		when(parentContainer.getResourceContainerID()).thenReturn(parentContainerId);
 		resourceRegistry.addResourceContainer(parentContainer);
-		
-		
+
 		String childContainerId = "container1";
 		SimulatedResourceContainer childContainer = new SimulatedResourceContainer(mockModel, childContainerId);
 		resourceRegistry.addResourceContainer(childContainer);
 		childContainer.setParentResourceContainer(parentContainerId);
 		parentContainer.addNestedResourceContainer(childContainerId);
-		
+
 		// check fallback to parent
-		var simProcess = Mockito.mock(SimuComSimProcess.class);
+		var simProcess = mock(SimuComSimProcess.class);
 		parentContainer.loadActiveResource(simProcess, "dummy", 100);
-		Mockito.verify(parentContainer).loadActiveResource(simProcess, "dummy", 100);
-		
+		verify(parentContainer).loadActiveResource(simProcess, "dummy", 100);
+
 		parentContainer.loadActiveResource(simProcess, "dummy", 0, 100);
-		Mockito.verify(parentContainer).loadActiveResource(simProcess, "dummy", 0, 100);
-		
+		verify(parentContainer).loadActiveResource(simProcess, "dummy", 0, 100);
+
 		parentContainer.loadActiveResource(simProcess, "dummy", 0, Collections.emptyMap(), 100);
-		Mockito.verify(parentContainer).loadActiveResource(simProcess, "dummy", 0, Collections.emptyMap(), 100);
-		
+		verify(parentContainer).loadActiveResource(simProcess, "dummy", 0, Collections.emptyMap(), 100);
+
 		parentContainer.loadActiveResource(simProcess, 0, "dummy", 100);
-		Mockito.verify(parentContainer).loadActiveResource(simProcess, 0, "dummy", 100);
-		
+		verify(parentContainer).loadActiveResource(simProcess, 0, "dummy", 100);
+
+	}
+
+	@Test
+	void testMissingResourceTypeException() {
+
+		// Given a container with no child container
+		String containerId = "container0";
+		SimulatedResourceContainer container = new SimulatedResourceContainer(mockModel, containerId);
+		resourceRegistry.addResourceContainer(container);
+
+		// check exception for missing resource is thrown
+		var simProcess = mock(SimuComSimProcess.class);
+
+		assertThrows(ResourceContainerIsMissingRequiredResourceType.class, () -> {
+			container.loadActiveResource(simProcess, "dummy", 100);
+		}, "expected exception for a missing required resource type");
+
+		assertThrows(ResourceContainerIsMissingRequiredResourceType.class, () -> {
+			container.loadActiveResource(simProcess, "dummy", 0, 100);
+		}, "expected exception for a missing required resource type");
+
+		assertThrows(ResourceContainerIsMissingRequiredResourceType.class, () -> {
+			container.loadActiveResource(simProcess, "dummy", 0, Collections.emptyMap(), 100);
+		}, "expected exception for a missing required resource type");
+
+		assertThrows(ResourceContainerIsMissingRequiredResourceType.class, () -> {
+			container.loadActiveResource(simProcess, 0, "dummy", 100);
+		}, "expected exception for a missing required resource type");
+
+	}
+
+	@Test
+	void testAddActiveResource() {
+
+		// Given a container with no child container
+		String containerId = "container0";
+		SimulatedResourceContainer container = new SimulatedResourceContainer(mockModel, containerId);
+		resourceRegistry.addResourceContainer(container);
+
+		var resource = mock(ProcessingResourceSpecification.class);
+		var resourceType = getMockResourceType();
+		var resourceContainer = getMockResourceContainer();
+		when(resource.getActiveResourceType_ActiveResourceSpecification()).thenReturn(resourceType);
+		when(resource.getResourceContainer_ProcessingResourceSpecification()).thenReturn(resourceContainer);
+		when(resource.getNumberOfReplicas()).thenReturn(42);
+		when(resource.isRequiredByContainer()).thenReturn(false);
+		when(resource.getMTTF()).thenReturn(42.0);
+		when(resource.getMTTR()).thenReturn(23.0);
+		PCMRandomVariable rate = CoreFactory.eINSTANCE.createPCMRandomVariable();
+		rate.setSpecification("5");
+		when(resource.getProcessingRate_ProcessingResourceSpecification()).thenReturn(rate);
+
+		var mockEntity = mock(IEntity.class);
+		when(simEngineFactory.createEntity(any(), anyString())).thenReturn(mockEntity);
+		var mockActiveResource = mock(SimDelayResource.class);
+		when(schedulingFactory.createSimDelayResource(any(), any())).thenReturn(mockActiveResource);
+		container.addActiveResourceWithoutCalculators(resource, null, containerId, SchedulingStrategy.DELAY);
+
 	}
 	
 	
-	
-	
+
+	private final ProcessingResourceType getMockResourceType() {
+		var mockResourceType = mock(ProcessingResourceType.class);
+		when(mockResourceType.getEntityName()).thenReturn("mockResourceType");
+		when(mockResourceType.getId()).thenReturn("mockResourceTypeId");
+		return mockResourceType;
+
+	}
+
+	private final ResourceContainer getMockResourceContainer() {
+		var mockResourceContainer = mock(ResourceContainer.class);
+		when(mockResourceContainer.getEntityName()).thenReturn("mockResourceContainer");
+		when(mockResourceContainer.getId()).thenReturn("mockResourceContainerId");
+		return mockResourceContainer;
+
+	}
 
 }

--- a/tests/de.uka.ipd.sdq.simucomframework.tests/src/de/uka/ipd/sdq/simucomframework/tests/SimulatedResourceContainerTests.java
+++ b/tests/de.uka.ipd.sdq.simucomframework.tests/src/de/uka/ipd/sdq/simucomframework/tests/SimulatedResourceContainerTests.java
@@ -105,16 +105,16 @@ class SimulatedResourceContainerTests {
 
 		// check fallback to parent
 		var simProcess = mock(SimuComSimProcess.class);
-		parentContainer.loadActiveResource(simProcess, "dummy", 100);
+		childContainer.loadActiveResource(simProcess, "dummy", 100);
 		verify(parentContainer).loadActiveResource(simProcess, "dummy", 100);
 
-		parentContainer.loadActiveResource(simProcess, "dummy", 0, 100);
+		childContainer.loadActiveResource(simProcess, "dummy", 0, 100);
 		verify(parentContainer).loadActiveResource(simProcess, "dummy", 0, 100);
 
-		parentContainer.loadActiveResource(simProcess, "dummy", 0, Collections.emptyMap(), 100);
+		childContainer.loadActiveResource(simProcess, "dummy", 0, Collections.emptyMap(), 100);
 		verify(parentContainer).loadActiveResource(simProcess, "dummy", 0, Collections.emptyMap(), 100);
 
-		parentContainer.loadActiveResource(simProcess, 0, "dummy", 100);
+		childContainer.loadActiveResource(simProcess, 0, "dummy", 100);
 		verify(parentContainer).loadActiveResource(simProcess, 0, "dummy", 100);
 
 	}

--- a/tests/de.uka.ipd.sdq.simucomframework.tests/src/de/uka/ipd/sdq/simucomframework/tests/SimulatedResourceContainerTests.java
+++ b/tests/de.uka.ipd.sdq.simucomframework.tests/src/de/uka/ipd/sdq/simucomframework/tests/SimulatedResourceContainerTests.java
@@ -156,6 +156,7 @@ class SimulatedResourceContainerTests {
 		SimulatedResourceContainer container = new SimulatedResourceContainer(mockModel, containerId);
 		resourceRegistry.addResourceContainer(container);
 
+		// we add an active resource
 		var resource = mock(ProcessingResourceSpecification.class);
 		var resourceType = getMockResourceType();
 		var resourceContainer = getMockResourceContainer();
@@ -174,6 +175,9 @@ class SimulatedResourceContainerTests {
 		var mockActiveResource = mock(SimDelayResource.class);
 		when(schedulingFactory.createSimDelayResource(any(), any())).thenReturn(mockActiveResource);
 		container.addActiveResourceWithoutCalculators(resource, null, containerId, SchedulingStrategy.DELAY);
+		
+		assertEquals(1, container.getActiveResources().size(), "we should have one active resource");
+		assertEquals(mockActiveResource, container.getActiveResources().stream().findFirst().get().getScheduledResource(), "the mock resource should be in our container");
 
 	}
 	

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -14,6 +14,7 @@
 	<modules>
 		<module>de.uka.ipd.sdq.codegen.simucontroller.tests</module>
 		<module>de.uka.ipd.sdq.simucomframework.variables.tests</module>
+		<module>de.uka.ipd.sdq.simucomframework.tests</module>
 		<!--<module>org.palladiosimulator.simucom.swtbot.tests</module>-->
 	</modules>
 	


### PR DESCRIPTION
this pr is adding a method for using the resource interfaces with parent resource containers that was missing from the simulated resource containers. This is needed for the test models for simulizar-5 to work