### PR TITLE
SIMULIZAR-164

### DIFF
--- a/bundles/de.uka.ipd.sdq.codegen.simucontroller/src/de/uka/ipd/sdq/codegen/simucontroller/runconfig/SimuComConfigurationTab.java
+++ b/bundles/de.uka.ipd.sdq.codegen.simucontroller/src/de/uka/ipd/sdq/codegen/simucontroller/runconfig/SimuComConfigurationTab.java
@@ -157,10 +157,10 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
         gd_nameField.widthHint = 70;
         this.nameField.setLayoutData(gd_nameField);
         this.nameField.addModifyListener(modifyListener);
-        
+
         final Label variationLabel = new Label(experimentrunGroup, SWT.NONE);
         variationLabel.setText("Variation Name:");
-        
+
         this.variationField = new Text(experimentrunGroup, SWT.BORDER);
         final GridData gd_variationField = new GridData(SWT.FILL, SWT.CENTER, true, false);
         gd_variationField.widthHint = 70;
@@ -489,7 +489,7 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
         } catch (final CoreException e) {
             this.nameField.setText("MyRun");
         }
-        
+
         try {
             this.variationField.setText(configuration.getAttribute(AbstractSimulationConfig.VARIATION_ID, ""));
         } catch (final CoreException e) {
@@ -504,14 +504,14 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
 
         try {
             this.maxMeasurementsField
-                    .setText(configuration.getAttribute(AbstractSimulationConfig.MAXIMUM_MEASUREMENT_COUNT, ""));
+                .setText(configuration.getAttribute(AbstractSimulationConfig.MAXIMUM_MEASUREMENT_COUNT, ""));
         } catch (final CoreException e) {
             this.maxMeasurementsField.setText("10000");
         }
 
         try {
             final String persistenceFrameworkName = configuration
-                    .getAttribute(AbstractSimulationConfig.PERSISTENCE_RECORDER_NAME, "");
+                .getAttribute(AbstractSimulationConfig.PERSISTENCE_RECORDER_NAME, "");
             final String[] items = this.persistenceCombo.getItems();
             for (int i = 0; i < items.length; i++) {
                 final String str = items[i];
@@ -527,7 +527,7 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
 
         try {
             this.checkLoggingButton
-                    .setSelection(configuration.getAttribute(AbstractSimulationConfig.VERBOSE_LOGGING, false));
+                .setSelection(configuration.getAttribute(AbstractSimulationConfig.VERBOSE_LOGGING, false));
         } catch (final CoreException e) {
             this.checkLoggingButton.setSelection(false);
         }
@@ -547,7 +547,7 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
         final String defaultBatchSize = "" + SimuComConfig.DEFAULT_CONFIDENCE_BATCH_SIZE;
         try {
             this.batchSizeField
-                    .setText(configuration.getAttribute(SimuComConfig.CONFIDENCE_BATCH_SIZE, defaultBatchSize));
+                .setText(configuration.getAttribute(SimuComConfig.CONFIDENCE_BATCH_SIZE, defaultBatchSize));
         } catch (final CoreException e) {
             this.batchSizeField.setText(defaultBatchSize);
         }
@@ -555,7 +555,7 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
         final String defaultMinNumberOfBatches = "" + SimuComConfig.DEFAULT_CONFIDENCE_MIN_NUMBER_OF_BATCHES;
         try {
             this.minNumberOfBatchesField.setText(configuration
-                    .getAttribute(SimuComConfig.CONFIDENCE_MIN_NUMBER_OF_BATCHES, defaultMinNumberOfBatches));
+                .getAttribute(SimuComConfig.CONFIDENCE_MIN_NUMBER_OF_BATCHES, defaultMinNumberOfBatches));
         } catch (final CoreException e) {
             this.minNumberOfBatchesField.setText(defaultMinNumberOfBatches);
         }
@@ -571,7 +571,7 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
 
         try {
             this.selectedModelElementURI = URI
-                    .createURI(configuration.getAttribute(SimuComConfig.CONFIDENCE_MODELELEMENT_URI, ""));
+                .createURI(configuration.getAttribute(SimuComConfig.CONFIDENCE_MODELELEMENT_URI, ""));
             final UsageScenario usageScenario = getUsageScenarioFromURI(this.selectedModelElementURI);
             this.selectedModelElementName = usageScenario.getEntityName();
             updateModelElementField(usageScenario);
@@ -584,7 +584,7 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
         // decide how to enable / disable them after initialising the values.
         try {
             final boolean isAutomaticBatches = configuration
-                    .getAttribute(SimuComConfig.CONFIDENCE_USE_AUTOMATIC_BATCHES, false);
+                .getAttribute(SimuComConfig.CONFIDENCE_USE_AUTOMATIC_BATCHES, false);
             this.useAutomatedBatchMeansCheckBox.setSelection(isAutomaticBatches);
 
             final boolean select = configuration.getAttribute(SimuComConfig.USE_CONFIDENCE, false);
@@ -615,7 +615,7 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
         }
         try {
             this.fixedSeedButton
-                    .setSelection(configuration.getAttribute(AbstractSimulationConfig.USE_FIXED_SEED, false));
+                .setSelection(configuration.getAttribute(AbstractSimulationConfig.USE_FIXED_SEED, false));
         } catch (final CoreException e) {
             this.fixedSeedButton.setSelection(false);
         }
@@ -623,7 +623,7 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
         for (int i = 0; i < 6; i++) {
             try {
                 this.seedText[i]
-                        .setText(configuration.getAttribute(AbstractSimulationConfig.FIXED_SEED_PREFIX + i, i + ""));
+                    .setText(configuration.getAttribute(AbstractSimulationConfig.FIXED_SEED_PREFIX + i, i + ""));
             } catch (final CoreException e) {
                 this.seedText[i].setText(i + "");
             }
@@ -736,16 +736,19 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
     public boolean isValid(final ILaunchConfiguration launchConfig) {
         setErrorMessage(null);
 
-        if (this.nameField.getText().equals("")) {
+        if (this.nameField.getText()
+            .equals("")) {
             setErrorMessage("ExperimentRun name is missing!");
             return false;
         }
-        /* No requirements for variationField*/
-        if (this.timeField.getText().equals("")) {
+        /* No requirements for variationField */
+        if (this.timeField.getText()
+            .equals("")) {
             setErrorMessage("Simulation time is missing!");
             return false;
         }
-        if (this.maxMeasurementsField.getText().equals("")) {
+        if (this.maxMeasurementsField.getText()
+            .equals("")) {
             setErrorMessage("Maximum Measurement counter is missing!");
             return false;
         }
@@ -785,10 +788,12 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
             }
         }
         // check confidence interval half-width
-        if (this.useConfidenceCheckBox.getSelection() && this.halfWidthField.getText().equals("")) {
+        if (this.useConfidenceCheckBox.getSelection() && this.halfWidthField.getText()
+            .equals("")) {
             setErrorMessage("Confidence interval half-width is missing!");
             return false;
-        } else if (this.useConfidenceCheckBox.getSelection() && this.halfWidthField.getText().length() > 0) {
+        } else if (this.useConfidenceCheckBox.getSelection() && this.halfWidthField.getText()
+            .length() > 0) {
             try {
                 final int halfWidth = Integer.parseInt(this.halfWidthField.getText());
                 if (halfWidth < 0 || halfWidth > 100) {
@@ -847,7 +852,7 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
                     this.modelFiles.add(usageFile);
 
                     this.selectedModelElementURI = URI
-                            .createURI(configuration.getAttribute(SimuComConfig.CONFIDENCE_MODELELEMENT_URI, ""));
+                        .createURI(configuration.getAttribute(SimuComConfig.CONFIDENCE_MODELELEMENT_URI, ""));
                     final UsageScenario usageScenario = getUsageScenarioFromURI(this.selectedModelElementURI);
                     this.selectedModelElementName = usageScenario.getEntityName();
                     updateModelElementField(usageScenario);

--- a/bundles/de.uka.ipd.sdq.codegen.simucontroller/src/de/uka/ipd/sdq/codegen/simucontroller/runconfig/SimuComConfigurationTab.java
+++ b/bundles/de.uka.ipd.sdq.codegen.simucontroller/src/de/uka/ipd/sdq/codegen/simucontroller/runconfig/SimuComConfigurationTab.java
@@ -25,6 +25,7 @@ import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -64,6 +65,7 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
     private Text timeField;
     private Text maxMeasurementsField;
     private Button checkLoggingButton;
+    private Button breakOnInvalidModelsButton;
 
     /** Confidence settings */
     private Button useConfidenceCheckBox;
@@ -130,6 +132,9 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
 
         /** Logging group */
         createLoggingGroup();
+
+        /** Model validation group */
+        createModelValidationGroup();
 
         /** Generator Seeds group */
         createGeneratorSeedsGroup(modifyListener);
@@ -372,6 +377,18 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
         this.checkLoggingButton.setSelection(false);
     }
 
+    protected void createModelValidationGroup() {
+        final Group loggingGroup = new Group(this.container, SWT.NONE);
+        loggingGroup.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false));
+        loggingGroup.setText("Model validation");
+        loggingGroup.setLayout(new GridLayout());
+        this.breakOnInvalidModelsButton = new Button(loggingGroup, SWT.CHECK);
+        this.breakOnInvalidModelsButton.setText("Break on invalid models");
+        this.breakOnInvalidModelsButton.addSelectionListener(SelectionListener
+            .widgetSelectedAdapter(it -> SimuComConfigurationTab.this.updateLaunchConfigurationDialog()));
+        this.breakOnInvalidModelsButton.setSelection(SimuComConfig.DEFAULT_SHOULD_THROW_EXCEPTION);
+    }
+
     /**
      * The generator seeds group, previous in analysis configuration tab, now the last section of
      * the SimuComConfigurationTab
@@ -533,6 +550,13 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
         }
 
         try {
+            this.breakOnInvalidModelsButton.setSelection(configuration
+                .getAttribute(SimuComConfig.SHOULD_THROW_EXCEPTION, SimuComConfig.DEFAULT_SHOULD_THROW_EXCEPTION));
+        } catch (final CoreException e) {
+            this.breakOnInvalidModelsButton.setSelection(SimuComConfig.DEFAULT_SHOULD_THROW_EXCEPTION);
+        }
+
+        try {
             this.levelField.setText(configuration.getAttribute(SimuComConfig.CONFIDENCE_LEVEL, "95"));
         } catch (final CoreException e) {
             this.levelField.setText("" + SimuComConfig.DEFAULT_CONFIDENCE_LEVEL);
@@ -669,6 +693,9 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
         configuration.setAttribute(SimuComConfig.CONFIDENCE_BATCH_SIZE, this.batchSizeField.getText());
         configuration.setAttribute(SimuComConfig.CONFIDENCE_MIN_NUMBER_OF_BATCHES,
                 this.minNumberOfBatchesField.getText());
+
+        configuration.setAttribute(SimuComConfig.SHOULD_THROW_EXCEPTION,
+                this.breakOnInvalidModelsButton.getSelection());
     }
 
     /*
@@ -708,6 +735,7 @@ public class SimuComConfigurationTab extends AbstractLaunchConfigurationTab {
         configuration.setAttribute(SimuComConfig.CONFIDENCE_BATCH_SIZE, SimuComConfig.DEFAULT_CONFIDENCE_BATCH_SIZE);
         configuration.setAttribute(SimuComConfig.CONFIDENCE_MIN_NUMBER_OF_BATCHES,
                 SimuComConfig.DEFAULT_CONFIDENCE_MIN_NUMBER_OF_BATCHES);
+        configuration.setAttribute(SimuComConfig.SHOULD_THROW_EXCEPTION, SimuComConfig.DEFAULT_SHOULD_THROW_EXCEPTION);
 
         // set default value for persistence framework
         final List<String> recorderNames = RecorderExtensionHelper.getRecorderNames();

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/SimuComConfig.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/SimuComConfig.java
@@ -47,11 +47,14 @@ public class SimuComConfig extends AbstractSimulationConfig implements Serializa
 
     /** SimuCom configuration tab */
     public static final String SIMULATE_FAILURES = "simulateFailures";
-    /** whether to simulate linking resources in detail, including marshalling/demarshalling, with Steffen's completions. */
+    /**
+     * whether to simulate linking resources in detail, including marshalling/demarshalling, with
+     * Steffen's completions.
+     */
     public static final String SIMULATE_LINKING_RESOURCES = "simulateLinkingResources";
-    /** whether to include throughput in the simulation without marshaling/demarshalling. */ 
+    /** whether to include throughput in the simulation without marshaling/demarshalling. */
     public static final String SIMULATE_THROUGHPUT_OF_LINKING_RESOURCES = "simulateThroughputOfLinkingResources";
-    
+
     public static final String USE_CONFIDENCE = "useConfidenceStopCondition";
     public static final String CONFIDENCE_LEVEL = "confidenceLevel";
     public static final String CONFIDENCE_HALFWIDTH = "confidenceHalfWidth";
@@ -92,16 +95,17 @@ public class SimuComConfig extends AbstractSimulationConfig implements Serializa
      *            SimuComConfig.CONFIDENCE_MODELELEMENT_URI
      *
      */
-    public SimuComConfig(final Map<String, Object> configuration, final boolean debug, IRecorderConfigurationFactory configurationFactory) {
+    public SimuComConfig(final Map<String, Object> configuration, final boolean debug,
+            IRecorderConfigurationFactory configurationFactory) {
         super(configuration, debug, configurationFactory);
         doInit(configuration, debug);
     }
-    
+
     public SimuComConfig(final Map<String, Object> configuration, final boolean debug) {
         super(configuration, debug);
         doInit(configuration, debug);
     }
-    
+
     private void doInit(final Map<String, Object> configuration, final boolean debug) {
         try {
             if (configuration.containsKey(SIMULATE_FAILURES)) {
@@ -111,9 +115,10 @@ public class SimuComConfig extends AbstractSimulationConfig implements Serializa
             if (configuration.containsKey(SIMULATE_LINKING_RESOURCES)) {
                 this.simulateLinkingResources = (Boolean) configuration.get(SIMULATE_LINKING_RESOURCES);
             }
-            
+
             if (configuration.containsKey(SIMULATE_THROUGHPUT_OF_LINKING_RESOURCES)) {
-                this.simulateThroughputOfLinkingResources = (Boolean) configuration.get(SIMULATE_THROUGHPUT_OF_LINKING_RESOURCES);
+                this.simulateThroughputOfLinkingResources = (Boolean) configuration
+                    .get(SIMULATE_THROUGHPUT_OF_LINKING_RESOURCES);
             }
 
             // confidence information is optional in the map. It this.useConfidence defaults to
@@ -129,8 +134,8 @@ public class SimuComConfig extends AbstractSimulationConfig implements Serializa
                 if (!this.automaticBatches) {
                     // only need batch settings if they are manually defined
                     this.batchSize = Integer.valueOf((String) configuration.get(CONFIDENCE_BATCH_SIZE));
-                    this.minNumberOfBatches = Integer.valueOf((String) configuration
-                            .get(CONFIDENCE_MIN_NUMBER_OF_BATCHES));
+                    this.minNumberOfBatches = Integer
+                        .valueOf((String) configuration.get(CONFIDENCE_MIN_NUMBER_OF_BATCHES));
 
                 }
 
@@ -156,7 +161,7 @@ public class SimuComConfig extends AbstractSimulationConfig implements Serializa
     public boolean getSimulateLinkingResources() {
         return simulateLinkingResources;
     }
-    
+
     public boolean getSimulateThroughputOfLinkingResources() {
         return simulateThroughputOfLinkingResources;
     }

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/SimuComConfig.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/SimuComConfig.java
@@ -26,6 +26,7 @@ public class SimuComConfig extends AbstractSimulationConfig implements Serializa
     private static final long serialVersionUID = -3364130550065874984L;
 
     public static final String SHOULD_THROW_EXCEPTION = "shouldThrowException";
+    public static final Boolean DEFAULT_SHOULD_THROW_EXCEPTION = true;
 
     // Default values
     /** Default name of model element for the stop condition confidence. */


### PR DESCRIPTION
Adds a field to simulation launch configurations that allows users to check whether they want the IDE should open a dialog in case of model validation issues before the simulation launch. The default value for if this should be done is true.

Requires PalladioSimulator/Palladio-Analyzer-SimuLizar#81