### PR TITLE
[SIMULIZAR-163] Adapt debug output to changed latency calculation

### DIFF
--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/AbstractScheduledResource.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/AbstractScheduledResource.java
@@ -160,6 +160,10 @@ public abstract class AbstractScheduledResource extends SimuComEntity
 			// TODO throw an exception or add a warning?
 			return;
 		}
+		
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(this.getName() + ": About to issue a demand of " + concreteDemand);
+        }
 
 		// LOGGER.info("Recording " + concreteDemand);
 		fireDemand(concreteDemand);

--- a/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/SimulatedLinkingResource.java
+++ b/bundles/de.uka.ipd.sdq.simucomframework/src/de/uka/ipd/sdq/simucomframework/resources/SimulatedLinkingResource.java
@@ -92,7 +92,7 @@ public class SimulatedLinkingResource extends AbstractScheduledResource {
         //latency is added as DemandModifyingBehavior in superclass
         final double result = demand / calculatedThroughput;
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("A network load of " + result + " has been determined.");
+            LOGGER.debug("A network load of " + result + " has been determined (before latency and any demand modification).");
         }
 
         return result;


### PR DESCRIPTION
The test case https://palladio-simulator.atlassian.net/browse/SIMULIZAR-104 relies on a debug output of the final network demand. Due to changes to the way latency is incorporated in the demand, we need some additional output. The test case has already been updated to refer to the new output.